### PR TITLE
Switch to installing infra from master until we sort out version tagging

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -17,7 +17,7 @@
     "aws-param-store": "^2.1.0",
     "aws-sdk": "^2.338.0",
     "child-process-promise": "^2.2.1",
-    "csw-infra": "git+https://github.com/alphagov/csw-infra#v1.0",
+    "csw-infra": "git+https://github.com/alphagov/csw-infra#master",
     "gulp": "^4.0.0",
     "gulp-data": "^1.3.1",
     "gulp-modify-file": "^1.0.1",


### PR DESCRIPTION
I was installing a tagged version of the infra codebase but it makes more sense - at least for now - to just install the current master branch.  