### PR TITLE
Refactor authentication and template handling

### DIFF
--- a/build/csw_components/_login-bar.scss
+++ b/build/csw_components/_login-bar.scss
@@ -21,7 +21,7 @@
 .csw-login-status--avatar {
     display:inline;
     width:2em;
-    height:2em
+    height:2em;
     border-radius:1em;
     vertical-align:middle;
 }

--- a/build/csw_components/_login-bar.scss
+++ b/build/csw_components/_login-bar.scss
@@ -11,4 +11,17 @@
 
 .csw-login-status {
     float: right;
+
+}
+
+.csw-login-status--text {
+    line-height: 2em;
+}
+
+.csw-login-status--avatar {
+    display:inline;
+    width:2em;
+    height:2em
+    border-radius:1em;
+    vertical-align:middle;
 }

--- a/build/gulp_tasks/6.environment.database.js
+++ b/build/gulp_tasks/6.environment.database.js
@@ -92,6 +92,8 @@ gulp.task('environment.database_create_tables', function() {
 
     var payload = {
         "Tables":[
+            "User",
+            "UserSession",
             "ProductTeam",
             "AccountSubscription",
             "AccountAudit",

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -68,8 +68,7 @@ def load_route_services():
 
     try:
         app.auth = AuthHandler(app)
-        app.base_url = app.auth.get_base_url(app.current_request)
-        app.flow = app.auth.get_auth_flow(app.base_url)
+        app.auth.initialise_flow(app.current_request)
 
         app.log.debug("Loaded auth")
 

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -11,7 +11,6 @@ import os
 
 from chalice import Chalice
 
-from chalicelib.template_handler import TemplateHandler
 from chalicelib.utilities import Utilities
 
 
@@ -62,6 +61,9 @@ class CloudSecurityWatch(Chalice):
 
 # TODO: Use the overloaded __call__ or route for this
 def load_route_services():
+    # This can't be imported until after app is declared
+    from chalicelib.auth import AuthHandler
+    from chalicelib.template_handler import TemplateHandler
 
     app.log.debug('Loading route services')
 
@@ -126,9 +128,6 @@ def read_asset(proxy):
 
 # Instantiate and initialise the Chalice child object
 app = CloudSecurityWatch(app_name='cloud-security-watch')
-
-# This can't be imported until after app is declared
-from chalicelib.auth import AuthHandler
 
 # switch debug logging on
 app.log.setLevel(logging.DEBUG)

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -68,6 +68,8 @@ def load_route_services():
 
     try:
         app.auth = AuthHandler(app)
+        app.base_url = app.auth.get_base_url(app.current_request)
+        app.flow = app.auth.get_auth_flow(app.base_url)
 
         app.log.debug("Loaded auth")
 

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -11,7 +11,6 @@ import os
 
 from chalice import Chalice
 
-from chalicelib.auth import AuthHandler
 from chalicelib.template_handler import TemplateHandler
 from chalicelib.utilities import Utilities
 
@@ -127,6 +126,10 @@ def read_asset(proxy):
 
 # Instantiate and initialise the Chalice child object
 app = CloudSecurityWatch(app_name='cloud-security-watch')
+
+# This can't be imported until after app is declared
+from chalicelib.auth import AuthHandler
+
 # switch debug logging on
 app.log.setLevel(logging.DEBUG)
 app.prefix = os.environ["CSW_PREFIX"]

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -344,6 +344,7 @@ class AuthHandler:
                 self.logged_in = True
                 self.login_data['authenticated'] = True
                 self.login_data['is_registered'] = True
+                self.login_data.update(self.user)
 
             else:
 

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -98,10 +98,10 @@ class AuthHandler:
 
         return self.flow
 
-    def get_request_url(self, request):
+    def get_base_url(self, request):
         """
         Returns the base URL from the current request
-        At present /app/ is appended to the URL
+        At present /app is appended to the URL
         When we implement CloudFront the /app/ should no longer be necessary
 
         :param dict request: The request object received by API Gateway
@@ -275,7 +275,7 @@ class AuthHandler:
                 # Then check for OAuth response code in QS
                 if "code" in req.query_params:
 
-                    url = self.get_request_url(req)
+                    url = self.get_base_url(req)
                     code = req.query_params["code"]
 
                     self.user = self.get_user_from_code(url, code)

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -42,8 +42,7 @@ class AuthHandler:
 
         # Initialise parameters for OAuth scopes and
         # JWT encryption
-        self.base_url = self.get_base_url(app.current_request)
-        self.flow = self.get_auth_flow(self.base_url)
+        self.flow = None
 
         self.token_algorithm = 'HS256'
 

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -228,7 +228,6 @@ class AuthHandler:
                 self.db.rollback()
 
         except Exception as error:
-            db_user = None
             user_registered = False
             self.app.log.debug("User not registered: " + str(error))
 

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -116,7 +116,7 @@ class AuthHandler:
 
         login_url, _ = auth_flow.authorization_url(
             prompt="select_account",
-            hd=self.auth.email_domain
+            hd=self.email_domain
         )
 
         return login_url

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -111,6 +111,12 @@ class AuthHandler:
 
         return self.flow
 
+    def initialise_flow(self, req):
+
+        self.base_url = self.get_base_url(req)
+
+        self.get_auth_flow(self.base_url)
+
     def get_auth_url(self, url):
 
         auth_flow = self.get_auth_flow(url)

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -357,8 +357,9 @@ class AuthHandler:
                     self.user = self.get_user_from_code(url, code)
 
                     # Copy auth result into login_data
-                    # self.login_data['authenticated'] = self.user['authenticated']
                     self.login_data.update(self.user)
+                    # Explicitly set authenticated property although this should
+                    self.login_data['authenticated'] = self.user['authenticated']
 
                     # Make sure the email Google OAuthed is on the correct domain
                     # This is a secondary protection as the Cloud Console credentials

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -113,7 +113,7 @@ class AuthHandler:
         protocol = 'https'
         if 'X-Forwarded-Proto' in request.headers:
             protocol = request.headers['X-Forwarded-Proto']
-        return protocol + "://" + request.headers['Host'] + "/app/"
+        return protocol + "://" + request.headers['Host'] + "/app"
 
     def get_user_token(self, request):
         """

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -58,6 +58,7 @@ class AuthHandler:
         self.cookie = None
         self.logged_in = False
         self.login_data = {
+            'authenticated': False,
             'is_registered': False
         }
 
@@ -327,6 +328,7 @@ class AuthHandler:
 
         self.logged_in = False
         self.login_data = {
+            'authenticated': False,
             'is_registered': False
         }
 

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -355,7 +355,9 @@ class AuthHandler:
 
                     self.user = self.get_user_from_code(url, code)
 
-                    self.login_data['authenticated'] = bool(self.user is not None)
+                    # Copy auth result into login_data
+                    # self.login_data['authenticated'] = self.user['authenticated']
+                    self.login_data.update(self.user)
 
                     # Make sure the email Google OAuthed is on the correct domain
                     # This is a secondary protection as the Cloud Console credentials
@@ -377,7 +379,7 @@ class AuthHandler:
 
             if self.logged_in:
 
-                self.login_data.update(self.user)
+                # self.login_data.update(self.user)
                 self.login_data["cookie"] = self.cookie
                 self.login_data["token"] = self.token
 

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -357,7 +357,7 @@ class AuthHandler:
                     self.user = self.get_user_from_code(url, code)
 
                     # Explicitly set authenticated property
-                    self.login_data['authenticated'] = self.user['authenticated']
+                    self.login_data['authenticated'] = bool(self.user is not None)
                     # Copy auth result into login_data
                     self.login_data.update(self.user)
 

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -356,10 +356,10 @@ class AuthHandler:
 
                     self.user = self.get_user_from_code(url, code)
 
+                    # Explicitly set authenticated property
+                    self.login_data['authenticated'] = self.user['authenticated']
                     # Copy auth result into login_data
                     self.login_data.update(self.user)
-                    # Explicitly set authenticated property although this should
-                    self.login_data['authenticated'] = self.user['authenticated']
 
                     # Make sure the email Google OAuthed is on the correct domain
                     # This is a secondary protection as the Cloud Console credentials

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -57,7 +57,9 @@ class AuthHandler:
         # Assume logged in status is false until tested
         self.cookie = None
         self.logged_in = False
-        self.login_data = {}
+        self.login_data = {
+            'is_registered': False
+        }
 
     def get_params(self):
         """

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -197,7 +197,7 @@ class AuthHandler:
                 # Update UserSession accessed date
                 try:
                     db_user = User.find_active_by_email(user['email'])
-                    UserSession.update(db_user)
+                    UserSession.accessed(db_user)
                 except Exception as error:
                     self.app.log.error("Failed to update session: "+str(error))
 

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -107,6 +107,17 @@ class AuthHandler:
 
         return self.flow
 
+    def get_auth_url(self, url):
+
+        auth_flow = self.get_auth_flow(url)
+
+        login_url, _ = auth_flow.authorization_url(
+            prompt="select_account",
+            hd=self.auth.email_domain
+        )
+
+        return login_url
+
     def get_base_url(self, request):
         """
         Returns the base URL from the current request
@@ -338,8 +349,9 @@ class AuthHandler:
 
                     # Make sure the email Google OAuthed is on the correct domain
                     # This is a secondary protection as the Cloud Console credentials
+                    self.login_data['is_registered'] = self.is_valid_user(self.user)
 
-                    if self.is_valid_user(self.user):
+                    if self.login_data['is_registered']:
 
                         self.user_jwt = self.get_jwt(self.user)
 

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -326,7 +326,9 @@ class AuthHandler:
         # Or by a response code QS variable from a Google OAuth request
 
         self.logged_in = False
-        self.login_data = {}
+        self.login_data = {
+            'is_registered': False
+        }
 
         try:
 
@@ -338,6 +340,7 @@ class AuthHandler:
 
                 self.token = self.get_user_token(req)
                 self.logged_in = True
+                self.login_data['is_registered'] = True
 
             else:
 

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -237,7 +237,6 @@ class AuthHandler:
             except Exception as error:
                 session = None
                 self.app.log.debug("User not registered: " + str(error))
-                self.db.rollback()
 
         except Exception as error:
             user_registered = False
@@ -274,7 +273,6 @@ class AuthHandler:
             models.UserSession.close(db_user)
         except Exception as error:
             self.app.log.error("Failed to close session: "+str(error))
-            self.db.rollback()
 
         return self.create_set_cookie_header("session", None, expiration)
 

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -113,7 +113,7 @@ class AuthHandler:
         protocol = 'https'
         if 'X-Forwarded-Proto' in request.headers:
             protocol = request.headers['X-Forwarded-Proto']
-        return protocol + "://" + request.headers['Host'] + "/app"
+        return protocol + "://" + request.headers['Host'] + "/app/"
 
     def get_user_token(self, request):
         """

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -212,7 +212,7 @@ class AuthHandler:
 
         domain_pattern = "\@" + self.email_domain.replace(".", "\\.") + "$"
 
-        domain_valid = re.search(domain_pattern, user['email'])
+        domain_valid = bool(re.search(domain_pattern, user['email']))
 
         # Check against User table for active user record
         try:

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -3,29 +3,36 @@ import re
 import datetime
 from http import cookies
 import jwt
-import json
 import google_auth_oauthlib.flow
-from chalicelib.aws.gds_secrets_manager_client import GdsSecretsManagerClient
 from chalicelib.aws.gds_ssm_client import GdsSsmClient
 
-
 class AuthHandler:
+    """
+    Implements Google OAuth flow
+    Implements JWT session tokens
+    Implements User and Session models
+
+    Gets google console api credentials, token secret and email domain from
+    SSM ParameterStore
+    TODO - Decouple params and pass to init method?
+
+    Authentication by decoding JWT or by parsing
+    Google OAuth return code query string param
+    """
 
     def __init__(self, app):
+
+        # app lets you use shared log method
         self.app = app
 
-        # TODO get this from AWS secret manager and move into a class method in auth
+        # Set time to expiry for session cookie
         self.cookie_expiration = datetime.timedelta(days=1)
 
-        # if 'CSW_ENV' in os.environ:
-        #    secrets = GdsSecretsManagerClient(self.app)
-        #    # secrets = Secrets()
-        #    self.csw_secrets = json.loads(secrets.get_secret_value(os.environ['CSW_ENV']))
-        #
-        #    self.token_secret = self.csw_secrets['token_secret']
-        #    self.client_config = secrets.parse_escaped_json_secret(self.csw_secrets['google_auth'])
+        # Retrieve Google OAuth credentials and token secret
         self.get_params()
 
+        # Initialise parameters for OAuth scopes and
+        # JWT encryption
         self.flow = None
         self.token_algorithm = 'HS256'
 
@@ -35,33 +42,54 @@ class AuthHandler:
             "https://www.googleapis.com/auth/userinfo.email"
         ]
 
-        self.user_info = "https://www.googleapis.com/oauth2/v2/userinfo?fields=email"
+        # TODO move to param store
+        self.email_domain = "digital.cabinet-office.gov.uk"
+
+        # Assume logged in status is false until tested
         self.cookie = None
         self.logged_in = False
         self.login_data = {}
 
-    def get_params(self): 
+    def get_params(self):
+        """
+        Retrieve the secrets from SSM.
+        """
 
         if 'CSW_ENV' in os.environ:
 
             env = os.environ['CSW_ENV']
-            self.app.log.debug(f"Get environment params: {env}")
 
             params = {
                 "client_config": f"/csw/google/api-credentials",
                 "token_secret": f"/csw/{env}/auth/token_secret"
             }
+
+            # Get list of SSM parameter names from dict
             param_list = list(params.values())
 
             ssm = GdsSsmClient(self.app)
 
+            # Get all listed parameters in one API call
             parameters = ssm.get_parameters(param_list, True)
 
             self.token_secret = ssm.get_parameter_value(parameters, params["token_secret"])
+
+            # Because the google creds are JSON they get escaped in the API response
+            # and need to be parsed into a dict for use
             google_config_param = ssm.get_parameter_value(parameters, params["client_config"])
             self.client_config = ssm.parse_escaped_json_parameter(google_config_param)
 
+        else:
+            self.app.log.debug("Environment variable CSW_ENV missing")
+
     def get_auth_flow(self, url):
+        """
+        Get as instance of the Google OAuth flow object
+        If the flow object has already been created it can be re-used
+
+        :param str url: The URL to return the user to after the auth process
+        :return google_auth_oauthlib.flow:
+        """
 
         if self.flow is None:
 
@@ -71,167 +99,206 @@ class AuthHandler:
         return self.flow
 
     def get_request_url(self, request):
+        """
+        Returns the base URL from the current request
+        At present /app/ is appended to the URL
+        When we implement CloudFront the /app/ should no longer be necessary
 
-        protocol = 'http'
+        :param dict request: The request object received by API Gateway
+        :return str: The URL to return to after the OAuth redirect
+        """
+
+        # Set default header for the case where X-Forwarded-Proto header is missing
+        # Assume https
+        protocol = 'https'
         if 'X-Forwarded-Proto' in request.headers:
             protocol = request.headers['X-Forwarded-Proto']
-        return protocol + "://" + request.headers['Host'] + "/app"
+        return protocol + "://" + request.headers['Host'] + "/app/"
 
     def get_user_token(self, request):
+        """
+        Gets the session token cookie value
 
-        cookie = cookies.SimpleCookie()
-        cookie.load(request.headers["cookie"])
-        token = cookie["session"].value
+        :param dict request: The request object received by API Gateway
+        :return str: The cookie value
+        """
+
+        token = self.get_cookie_value(request, "session")
         return token
 
     def get_cookie_value(self, req, cookie_name):
+        """
+        Get cookie value or None if missing
+
+        :param dict req: The http request dict
+        :param str cookie_name: The name of the cookie to get
+        :return str: Value from http cookie
+        """
 
         value = None
 
         if "cookie" in req.headers:
-
             cookie = cookies.SimpleCookie()
             cookie.load(req.headers["cookie"])
+
             if cookie_name in cookie:
                 value = cookie[cookie_name].value
 
         return value
 
     def read_jwt(self, user_jwt):
+        """
+        Decode the token data using the secret from SSM
+
+        :param user_jwt: JWT token string
+        :return dict: The decoded user data dict
+        """
 
         user = None
 
-        self.app.log.debug('jwt: ' + user_jwt)
-
         if (user_jwt is not None):
-            user = jwt.decode(user_jwt.encode(), self.token_secret, algorithms=[self.token_algorithm])
-
-            self.app.log.debug('user data: ' + str(user))
+            try:
+                user = jwt.decode(user_jwt.encode(), self.token_secret, algorithms=[self.token_algorithm])
+            except Exception as error:
+                self.app.log.error("Failed to decode session token: " + str(error))
 
         return user
 
     def has_valid_user(self, req):
+        """
+        Read and decode the session JWT.
+
+        :param dict req: The request object
+        :return dict: The details of the user encoded in the JWT
+        """
+
         # TODO: There should be a list of valid sessions stored somewhere and
         # TODO: the session ID should be checked against that.  For now it just makes sure
         # TODO: there is a session cookie at all set by this domain.  Not very secure.
+
         user = None
 
         if "cookie" in req.headers:
 
-            user_jwt = self.get_cookie_value(req, "session")
+            user_jwt = self.get_user_token(req)
 
             if user_jwt is not None:
                 user = self.read_jwt(user_jwt)
 
         return user
 
-    # Generate a cookie header value
     def generate_cookie_header_val(self, token):
+        """
+        Generate a session cookie with the default expiry
 
-        cookie = cookies.SimpleCookie()
-        cookie["session"] = token
+        :param str token: The value to store in the session cookie
+        :return str:
+        """
+
         expiration = datetime.datetime.now() + self.cookie_expiration
-        cookie["session"]["expires"] = expiration.strftime("%a, %d-%b-%Y %H:%M:%S PST")
-        cookie["session"]["path"] = "/"
 
-        # Workaround the fact that cookie.output returns a string like: 'Set-Cookie: session=650406237; etc..'
-        # but we don't want the 'Set-Cookie: ' part in the actual header.
-        raw_cookie_output = cookie.output()
-        cookie_val = raw_cookie_output.replace("Set-Cookie: ", "")
-
-        return cookie_val
+        return self.create_set_cookie_header("session", token, expiration)
 
     def generate_logout_header_val(self):
+        """
+        Generate a session cookie that expires immediately to force logout
+
+        :return str:
+        """
+
+        expiration = datetime.datetime.now()
+
+        return self.create_set_cookie_header("session", None, expiration)
+
+    def create_set_cookie_header(self, cookie_name, cookie_value, expiration):
+        """
+        Create the value for a Set-Cookie http header for the session cookie
+
+        :param token:
+        :param expiration:
+        :return:
+        """
 
         cookie = cookies.SimpleCookie()
-        cookie["session"] = None
-        expiration = datetime.datetime.now()
-        cookie["session"]["expires"] = expiration.strftime("%a, %d-%b-%Y %H:%M:%S PST")
-        cookie["session"]["path"] = "/"
+        cookie[cookie_name] = cookie_value
+        cookie[cookie_name]["expires"] = expiration.strftime("%a, %d-%b-%Y %H:%M:%S PST")
+        cookie[cookie_name]["path"] = "/"
 
         # Workaround the fact that cookie.output returns a string like: 'Set-Cookie: session=650406237; etc..'
         # but we don't want the 'Set-Cookie: ' part in the actual header.
         raw_cookie_output = cookie.output()
-        cookie_val = raw_cookie_output.replace("Set-Cookie: ", "")
 
-        return cookie_val
+        # Remove the Set-Cookie: prefix. Headers are passed as a dict to the response
+        cookie_header = raw_cookie_output.replace("Set-Cookie: ", "")
+
+        return cookie_header
 
     def get_user_from_code(self, url, code):
 
         flow = self.get_auth_flow(url)
 
-        self.app.log.debug("get_credentials_from_code: got flow")
-
-        self.app.log.debug("request context: " + str(self.app.current_request.context))
-
         self.google_token = flow.fetch_token(code=code)
-
-        self.app.log.debug("get_credentials_from_code: got token: " + str(self.google_token))
 
         self.session = flow.authorized_session()
 
-        self.user_data = self.session.get('https://www.googleapis.com/userinfo/v2/me').json()
-
-        self.user = json.dumps(self.user_data)
+        self.user = self.session.get('https://www.googleapis.com/userinfo/v2/me').json()
 
         return self.user
 
     def get_jwt(self, user):
 
-        user_jwt = jwt.encode(json.loads(user), self.token_secret, algorithm=self.token_algorithm).decode('utf-8')
+        user_jwt = jwt.encode(user, self.token_secret, algorithm=self.token_algorithm).decode('utf-8')
         return user_jwt
 
     def try_login(self, req):
 
+        # By default any request is unauthenticated
+        # Requests can be authenticated by an un-expired session cookie
+        # Or by a response code QS variable from a Google OAuth request
+
+        self.logged_in = False
+        self.login_data = {}
+
         try:
-            self.user_data = self.has_valid_user(req)
 
-            if self.user_data is not None:
+            # First check for session cookie
+            # Returns user details object or None if no session cookie
+            self.user = self.has_valid_user(req)
 
-                self.app.log.debug('request user is set')
+            if self.user is not None:
 
                 self.token = self.get_user_token(req)
                 self.logged_in = True
 
             else:
 
-                self.app.log.debug('no user check for code param')
-
+                # Then check for OAuth response code in QS
                 if "code" in req.query_params:
 
-                    self.app.log.debug('')
                     url = self.get_request_url(req)
                     code = req.query_params["code"]
 
-                    self.app.log.debug(f"code: {code}")
-
                     self.user = self.get_user_from_code(url, code)
 
-                    # Make sure the email Google OAuthed is on the GDS domain
-                    if re.search("digital\.cabinet-office\.gov\.uk", self.user_data['email']):
+                    # Make sure the email Google OAuthed is on the correct domain
+                    # This is a secondary protection as the Cloud Console credentials
+
+                    domain_pattern = "\@" + self.email_domain.replace(".","\\.") + "$"
+
+                    if re.search(domain_pattern, self.user['email']):
 
                         self.user_jwt = self.get_jwt(self.user)
 
                         self.cookie = self.generate_cookie_header_val(self.user_jwt)
 
-                        self.token = self.google_token
+                        self.token = self.user_jwt
 
                         self.logged_in = True
 
-                    else:
-                        self.app.log.debug(json.dumps(self.user_data))
-                        self.logged_in = False
-                else:
-                    self.logged_in = False
-
             if self.logged_in:
-                self.login_data.update(self.user_data)
+                self.login_data.update(self.user)
                 self.login_data["cookie"] = self.cookie
                 self.login_data["token"] = self.token
-            else:
-                # explicitly empty login data
-                self.login_data = {}
-
 
         except Exception as err:
             self.app.log.debug(str(err))

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -340,6 +340,7 @@ class AuthHandler:
 
                 self.token = self.get_user_token(req)
                 self.logged_in = True
+                self.login_data['authenticated'] = True
                 self.login_data['is_registered'] = True
 
             else:
@@ -351,6 +352,8 @@ class AuthHandler:
                     code = req.query_params["code"]
 
                     self.user = self.get_user_from_code(url, code)
+
+                    self.login_data['authenticated'] = (self.user is not None)
 
                     # Make sure the email Google OAuthed is on the correct domain
                     # This is a secondary protection as the Cloud Console credentials

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -355,12 +355,16 @@ class AuthHandler:
 
                     self.user = self.get_user_from_code(url, code)
 
-                    self.login_data['authenticated'] = (self.user is not None)
+                    self.login_data['authenticated'] = bool(self.user is not None)
 
                     # Make sure the email Google OAuthed is on the correct domain
                     # This is a secondary protection as the Cloud Console credentials
-                    self.login_data['is_registered'] = self.is_valid_user(self.user)
+                    if self.login_data['authenticated']:
 
+                        # Check that the user has an active account in CSW
+                        self.login_data['is_registered'] = self.is_valid_user(self.user)
+
+                    # If both authenticated and registered then log them in.
                     if self.login_data['is_registered']:
 
                         self.user_jwt = self.get_jwt(self.user)
@@ -372,11 +376,13 @@ class AuthHandler:
                         self.logged_in = True
 
             if self.logged_in:
+
                 self.login_data.update(self.user)
                 self.login_data["cookie"] = self.cookie
                 self.login_data["token"] = self.token
 
         except Exception as err:
+
             self.app.log.debug(str(err))
             self.login_data["cookie"] = None
             self.login_data["message"] = "Login failed"
@@ -385,4 +391,7 @@ class AuthHandler:
         return self.logged_in
 
     def get_login_data(self):
+
+        self.app.log.debug(str(self.login_data))
+
         return self.login_data

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -219,21 +219,18 @@ class AuthHandler:
             db_user = User.find_active_by_email(user['email'])
             user_registered = True
 
-        except Exception as error:
-            db_user = None
-            user_registered = False
-            self.app.log.debug("User not registered: " + str(error))
-
-        # Create UserSession record
-        if user_registered:
-
+            # Create UserSession record
             try:
                 session = UserSession.start(db_user)
-            except:
+            except Exception as error:
                 session = None
                 self.app.log.debug("User not registered: " + str(error))
                 self.db.rollback()
 
+        except Exception as error:
+            db_user = None
+            user_registered = False
+            self.app.log.debug("User not registered: " + str(error))
 
         valid = domain_valid & user_registered
 
@@ -265,6 +262,7 @@ class AuthHandler:
             db_user = User.find_active_by_email(self.user['email'])
             UserSession.close(db_user)
         except Exception as error:
+            self.app.log.error("Failed to close session: "+str(error))
             self.db.rollback()
 
         return self.create_set_cookie_header("session", None, expiration)

--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -42,7 +42,9 @@ class AuthHandler:
 
         # Initialise parameters for OAuth scopes and
         # JWT encryption
-        self.flow = None
+        self.base_url = self.get_base_url(app.current_request)
+        self.flow = self.get_auth_flow(self.base_url)
+
         self.token_algorithm = 'HS256'
 
         self.scopes = [
@@ -358,13 +360,12 @@ class AuthHandler:
 
                     # Explicitly set authenticated property
                     self.login_data['authenticated'] = bool(self.user is not None)
-                    # Copy auth result into login_data
-                    self.login_data.update(self.user)
 
                     # Make sure the email Google OAuthed is on the correct domain
                     # This is a secondary protection as the Cloud Console credentials
                     if self.login_data['authenticated']:
-
+                        # Copy auth result into login_data
+                        self.login_data.update(self.user)
                         # Check that the user has an active account in CSW
                         self.login_data['is_registered'] = self.is_valid_user(self.user)
 

--- a/chalice/chalicelib/database_handle.py
+++ b/chalice/chalicelib/database_handle.py
@@ -174,7 +174,7 @@ class BaseModel(peewee.Model):
         try:
             item = super().save(force_insert, only)
         except Exception as error:
-            item = None
+            item = 0
             self._meta.database.app.log.error("Save failed: "+str(error))
             self._meta.database.rollback()
         return item

--- a/chalice/chalicelib/database_handle.py
+++ b/chalice/chalicelib/database_handle.py
@@ -169,3 +169,21 @@ class BaseModel(peewee.Model):
     class Meta:
         database = DatabaseHandle().get_handle()
         schema = "public"
+
+    def save(self, force_insert=False, only=None):
+        try:
+            item = super().save(force_insert, only)
+        except Exception as error:
+            item = None
+            self._meta.database.rollback()
+        return item
+
+    @classmethod
+    def create(cls, **query):
+        try:
+            item = super().create(**query)
+        except Exception as error:
+            item = None
+            cls._meta.database.rollback()
+        return item
+

--- a/chalice/chalicelib/database_handle.py
+++ b/chalice/chalicelib/database_handle.py
@@ -175,6 +175,7 @@ class BaseModel(peewee.Model):
             item = super().save(force_insert, only)
         except Exception as error:
             item = None
+            self._meta.database.app.log.error("Save failed: "+str(error))
             self._meta.database.rollback()
         return item
 
@@ -184,6 +185,7 @@ class BaseModel(peewee.Model):
             item = super().create(**query)
         except Exception as error:
             item = None
+            cls._meta.database.app.log.error("Create failed: " + str(error))
             cls._meta.database.rollback()
         return item
 

--- a/chalice/chalicelib/demos.py
+++ b/chalice/chalicelib/demos.py
@@ -100,8 +100,8 @@ AUDIT = {
 def demo_index():
     app.dummy_data = AUDIT
     load_route_services()
-    response = app.templates.render_authorized_route_template(
-        '/',
+    response = app.templates.render_authorized_template(
+        'logged_in.html',
         app.current_request,
         {
             "name": "[User Name]"
@@ -114,8 +114,8 @@ def demo_index():
 def demo_audit_list():
     app.dummy_data = AUDIT
     load_route_services()
-    response = app.templates.render_authorized_route_template(
-        '/audit',
+    response = app.templates.render_authorized_template(
+        'audit_list.html',
         app.current_request,
         app.dummy_data
     )
@@ -127,8 +127,8 @@ def demo_audit_report(id):
     app.dummy_data = AUDIT
     load_route_services()
     app.templates = TemplateHandler(app)
-    response = app.templates.render_authorized_route_template(
-        '/audit/{id}',
+    response = app.templates.render_authorized_template(
+        'audit.html',
         app.current_request,
         app.dummy_data["audits"][0]
     )
@@ -166,8 +166,8 @@ def test_ports_ingress_ssh():
             "compliance_results": groups,
             "tested": True
         }
-        response = app.templates.render_authorized_route_template(
-            '/test/ports_ingress_ssh',
+        response = app.templates.render_authorized_template(
+            'test_evaluation.html',
             app.current_request,
             template_data
         )
@@ -202,8 +202,8 @@ def test_ports_ingress_open():
         template_data["criteria"][0]["compliance_results"] = groups
         template_data["criteria"][0]["compliance_summary"] = summary
         template_data["criteria"][0]["tested"] = True
-        response = app.templates.render_authorized_route_template(
-            '/audit/{id}',
+        response = app.templates.render_authorized_template(
+            'test_evaluation.html',
             app.current_request,
             template_data
         )
@@ -249,8 +249,8 @@ def test_root_mfa():
             "compliance_results": data,
             "tested": True
         }
-        response = app.templates.render_authorized_route_template(
-            '/test/ports_ingress_ssh',
+        response = app.templates.render_authorized_template(
+            'test_evaluation.html',
             app.current_request,
             template_data
         )
@@ -295,8 +295,8 @@ def validate_iam_policy():
             "compliance_results": data,
             "tested": True
         }
-        response = app.templates.render_authorized_route_template(
-            '/test/validate_iam_policy',
+        response = app.templates.render_authorized_template(
+            'test_evaluation.html',
             app.current_request,
             template_data
         )

--- a/chalice/chalicelib/demos.py
+++ b/chalice/chalicelib/demos.py
@@ -5,6 +5,7 @@ and demo routes with static data
 """
 
 from datetime import datetime
+import os
 
 from chalice import Response
 
@@ -146,7 +147,8 @@ def test_ports_ingress_ssh():
             "chalicelib.criteria.aws_ec2_security_group_ingress_ssh.AwsEc2SecurityGroupIngressSsh"
         )
         ec2 = client(app)
-        session = ec2.get_session(account='103495720024', role='csw-dan_CstSecurityInspectorRole')
+        env = os.environ['CSW_ENV']
+        session = ec2.get_session(account='103495720024', role=f'csw-{env}_CstSecurityInspectorRole')
         region = 'eu-west-1'
         groups = ec2.get_data(session, **{"region": region})
         for group in groups:
@@ -185,7 +187,8 @@ def test_ports_ingress_open():
             "chalicelib.criteria.aws_ec2_security_group_ingress_open.AwsEc2SecurityGroupIngressOpen"
         )
         ec2 = client(app)
-        session = ec2.get_session(account='103495720024', role='csw-dan_CstSecurityInspectorRole')
+        env = os.environ['CSW_ENV']
+        session = ec2.get_session(account='103495720024', role=f'csw-{env}_CstSecurityInspectorRole')
         params = {
             "region": 'eu-west-1'
         }
@@ -219,9 +222,10 @@ def test_root_mfa():
             "chalicelib.criteria.aws_support_root_mfa.AwsSupportRootMfa"
         )
         support = client(app)
+        env = os.environ['CSW_ENV']
         session = support.get_session(
             account='103495720024',
-            role='csw-dan_CstSecurityInspectorRole'
+            role=f'csw-{env}_CstSecurityInspectorRole'
         )
         data = support.get_data(session)
         criterion = {
@@ -265,9 +269,10 @@ def validate_iam_policy():
             "chalicelib.criteria.aws_iam_validate_inspector_policy.AwsIamValidateInspectorPolicy"
         )
         iam = client(app)
+        env = os.environ['CSW_ENV']
         session = iam.get_session(
             account='103495720024',
-            role='csw-dan_CstSecurityInspectorRole'
+            role=f'csw-{env}_CstSecurityInspectorRole'
         )
         data = iam.get_data(session)
         criterion = {

--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -54,7 +54,8 @@ class User(BaseModel):
     class Meta:
         table_name = "user"
 
-    def find_active_by_email(self, email):
+    @classmethod
+    def find_active_by_email(cls, email):
         """
         Look for a user record with active true and matching the email address
 
@@ -62,7 +63,7 @@ class User(BaseModel):
         :param email:
         :return self instance:
         """
-        user = self.get(email=email, active=True)
+        user = cls.get(email=email, active=True)
 
         return user
 
@@ -84,7 +85,8 @@ class UserSession(BaseModel):
         table_name = "user_session"
 
 
-    def start(self, user):
+    @classmethod
+    def start(cls, user):
         """
         Create a new session for the current user
 
@@ -95,7 +97,7 @@ class UserSession(BaseModel):
 
         now = datetime.now()
 
-        session = self.create(
+        session = cls.create(
             user_id = user,
             date_opened = now,
             date_accessed = now,
@@ -104,14 +106,15 @@ class UserSession(BaseModel):
 
         return session
 
-    def update(self, user):
+    @classmethod
+    def update(cls, user):
         """
         Update the date_accessed field with the current time
 
         :param user:
         :return:
         """
-        session = self.get(user_id=user, date_closed=None)
+        session = cls.get(user_id=user, date_closed=None)
 
         now = datetime.now()
 
@@ -119,13 +122,14 @@ class UserSession(BaseModel):
 
         return session
 
-    def close(self, user):
+    @classmethod
+    def close(cls, user):
         """
         Update the current session date_closed with the current time
         :param user:
         :return:
         """
-        session = self.get(user_id=user, date_closed=None)
+        session = cls.get(user_id=user, date_closed=None)
 
         now = datetime.now()
 

--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -47,12 +47,24 @@ class User(BaseModel):
     that domain.
     Only people in this table (and marked active) should be allowed to login.
     """
-    email = CharField()
+    email = CharField(unique=True)
     name = CharField()
     active = BooleanField()
 
     class Meta:
         table_name = "user"
+
+    def find_active_by_email(self, email):
+        """
+        Look for a user record with active true and matching the email address
+
+        Raises DoesNotExist
+        :param email:
+        :return self instance:
+        """
+        user = self.get(email=email, active=True)
+
+        return user
 
 dbh.add_model("User", User)
 
@@ -70,6 +82,57 @@ class UserSession(BaseModel):
 
     class Meta:
         table_name = "user_session"
+
+
+    def start(self, user):
+        """
+        Create a new session for the current user
+
+        Raises Exception(Not sure which one)
+        :param user:
+        :return:
+        """
+
+        now = datetime.now()
+
+        session = self.create(
+            user_id = user,
+            date_opened = now,
+            date_accessed = now,
+            date_closed = None
+        )
+
+        return session
+
+    def update(self, user):
+        """
+        Update the date_accessed field with the current time
+
+        :param user:
+        :return:
+        """
+        session = self.get(user_id=user, date_closed=None)
+
+        now = datetime.now()
+
+        session.update(date_accessed = now)
+
+        return session
+
+    def close(self, user):
+        """
+        Update the current session date_closed with the current time
+        :param user:
+        :return:
+        """
+        session = self.get(user_id=user, date_closed=None)
+
+        now = datetime.now()
+
+        session.update(date_accessed=now, date_closed=now)
+
+        return session
+
 
 dbh.add_model("UserSession", UserSession)
 

--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -107,7 +107,7 @@ class UserSession(BaseModel):
         return session
 
     @classmethod
-    def update(cls, user):
+    def accessed(cls, user):
         """
         Update the date_accessed field with the current time
 

--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -39,8 +39,8 @@ class UserSession(database_handle.BaseModel):
     UserSession records login sessions against users so we can track things
     like how often and for how long the tool is being used
     """
-    date_opened = peewee.DateTimeField(default=datetime.now)
-    date_accessed = peewee.DateTimeField(default=datetime.now)
+    date_opened = peewee.DateTimeField(default=datetime.datetime.now)
+    date_accessed = peewee.DateTimeField(default=datetime.datetime.now)
     date_closed = peewee.DateTimeField(null=True)
 
     user_id = peewee.ForeignKeyField(User, backref='sessions')

--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -6,6 +6,40 @@ from app import app  # used only for logging
 from chalicelib import database_handle
 
 
+class User(BaseModel):
+    """
+    Google OAuth is used to authenticate users to a specified email domain
+    We want to further limit the use of this tool to specific users within
+    that domain.
+    Only people in this table (and marked active) should be allowed to login.
+    """
+    email = CharField()
+    name = CharField()
+    active = BooleanField()
+
+    class Meta:
+        table_name = "user"
+
+dbh.add_model("User", User)
+
+
+class UserSession(BaseModel):
+    """
+    UserSession records login sessions against users so we can track things
+    like how often and for how long the tool is being used
+    """
+    date_opened = DateTimeField(default=datetime.now)
+    date_accessed = DateTimeField(default=datetime.now)
+    date_closed = DateTimeField()
+
+    user_id = ForeignKeyField(User, backref='sessions')
+
+    class Meta:
+        table_name = "user_session"
+
+dbh.add_model("UserSession", UserSession)
+
+
 # Create a product team reference table to link AWS
 # accounts to the teams who they belong to
 class ProductTeam(database_handle.BaseModel):

--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -6,50 +6,16 @@ from app import app  # used only for logging
 from chalicelib import database_handle
 
 
-class User(BaseModel):
+class User(database_handle.BaseModel):
     """
     Google OAuth is used to authenticate users to a specified email domain
     We want to further limit the use of this tool to specific users within
     that domain.
     Only people in this table (and marked active) should be allowed to login.
     """
-    email = CharField()
-    name = CharField()
-    active = BooleanField()
-
-    class Meta:
-        table_name = "user"
-
-dbh.add_model("User", User)
-
-
-class UserSession(BaseModel):
-    """
-    UserSession records login sessions against users so we can track things
-    like how often and for how long the tool is being used
-    """
-    date_opened = DateTimeField(default=datetime.now)
-    date_accessed = DateTimeField(default=datetime.now)
-    date_closed = DateTimeField()
-
-    user_id = ForeignKeyField(User, backref='sessions')
-
-    class Meta:
-        table_name = "user_session"
-
-dbh.add_model("UserSession", UserSession)
-
-
-class User(BaseModel):
-    """
-    Google OAuth is used to authenticate users to a specified email domain
-    We want to further limit the use of this tool to specific users within
-    that domain.
-    Only people in this table (and marked active) should be allowed to login.
-    """
-    email = CharField(unique=True)
-    name = CharField()
-    active = BooleanField()
+    email = peewee.CharField(unique=True)
+    name = peewee.CharField()
+    active = peewee.BooleanField()
 
     class Meta:
         table_name = "user"
@@ -67,19 +33,17 @@ class User(BaseModel):
 
         return user
 
-dbh.add_model("User", User)
 
-
-class UserSession(BaseModel):
+class UserSession(database_handle.BaseModel):
     """
     UserSession records login sessions against users so we can track things
     like how often and for how long the tool is being used
     """
-    date_opened = DateTimeField(default=datetime.now)
-    date_accessed = DateTimeField(default=datetime.now)
-    date_closed = DateTimeField(null=True)
+    date_opened = peewee.DateTimeField(default=datetime.now)
+    date_accessed = peewee.DateTimeField(default=datetime.now)
+    date_closed = peewee.DateTimeField(null=True)
 
-    user_id = ForeignKeyField(User, backref='sessions')
+    user_id = peewee.ForeignKeyField(User, backref='sessions')
 
     class Meta:
         table_name = "user_session"
@@ -141,115 +105,6 @@ class UserSession(BaseModel):
         session.save()
 
         return session
-
-
-dbh.add_model("UserSession", UserSession)
-
-
-class User(BaseModel):
-    """
-    Google OAuth is used to authenticate users to a specified email domain
-    We want to further limit the use of this tool to specific users within
-    that domain.
-    Only people in this table (and marked active) should be allowed to login.
-    """
-    email = CharField(unique=True)
-    name = CharField()
-    active = BooleanField()
-
-    class Meta:
-        table_name = "user"
-
-    @classmethod
-    def find_active_by_email(cls, email):
-        """
-        Look for a user record with active true and matching the email address
-
-        Raises DoesNotExist
-        :param email:
-        :return self instance:
-        """
-        user = cls.get(email=email, active=True)
-
-        return user
-
-dbh.add_model("User", User)
-
-
-class UserSession(BaseModel):
-    """
-    UserSession records login sessions against users so we can track things
-    like how often and for how long the tool is being used
-    """
-    date_opened = DateTimeField(default=datetime.now)
-    date_accessed = DateTimeField(default=datetime.now)
-    date_closed = DateTimeField(null=True)
-
-    user_id = ForeignKeyField(User, backref='sessions')
-
-    class Meta:
-        table_name = "user_session"
-
-
-    @classmethod
-    def start(cls, user):
-        """
-        Create a new session for the current user
-
-        Raises Exception(Not sure which one)
-        :param user:
-        :return:
-        """
-
-        now = datetime.now()
-
-        session = cls.create(
-            user_id = user,
-            date_opened = now,
-            date_accessed = now,
-            date_closed = None
-        )
-
-        return session
-
-    @classmethod
-    def accessed(cls, user):
-        """
-        Update the date_accessed field with the current time
-
-        :param user:
-        :return:
-        """
-        session = cls.get(user_id=user, date_closed=None)
-
-        now = datetime.now()
-
-        #session.update(date_accessed = now)
-        session.date_accessed = now
-        session.save()
-
-        return session
-
-    @classmethod
-    def close(cls, user):
-        """
-        Update the current session date_closed with the current time
-        :param user:
-        :return:
-        """
-        session = cls.get(user_id=user, date_closed=None)
-
-        now = datetime.now()
-
-        # session.update(date_accessed=now, date_closed=now)
-        session.date_accessed = now
-        session.date_closed = now
-        session.save()
-
-        return session
-
-
-dbh.add_model("UserSession", UserSession)
 
 
 # Create a product team reference table to link AWS

--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -40,6 +40,40 @@ class UserSession(BaseModel):
 dbh.add_model("UserSession", UserSession)
 
 
+class User(BaseModel):
+    """
+    Google OAuth is used to authenticate users to a specified email domain
+    We want to further limit the use of this tool to specific users within
+    that domain.
+    Only people in this table (and marked active) should be allowed to login.
+    """
+    email = CharField()
+    name = CharField()
+    active = BooleanField()
+
+    class Meta:
+        table_name = "user"
+
+dbh.add_model("User", User)
+
+
+class UserSession(BaseModel):
+    """
+    UserSession records login sessions against users so we can track things
+    like how often and for how long the tool is being used
+    """
+    date_opened = DateTimeField(default=datetime.now)
+    date_accessed = DateTimeField(default=datetime.now)
+    date_closed = DateTimeField()
+
+    user_id = ForeignKeyField(User, backref='sessions')
+
+    class Meta:
+        table_name = "user_session"
+
+dbh.add_model("UserSession", UserSession)
+
+
 # Create a product team reference table to link AWS
 # accounts to the teams who they belong to
 class ProductTeam(database_handle.BaseModel):

--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -77,7 +77,7 @@ class UserSession(BaseModel):
     """
     date_opened = DateTimeField(default=datetime.now)
     date_accessed = DateTimeField(default=datetime.now)
-    date_closed = DateTimeField()
+    date_closed = DateTimeField(null=True)
 
     user_id = ForeignKeyField(User, backref='sessions')
 

--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -118,7 +118,9 @@ class UserSession(BaseModel):
 
         now = datetime.now()
 
-        session.update(date_accessed = now)
+        #session.update(date_accessed = now)
+        session.date_accessed = now
+        session.save()
 
         return session
 
@@ -133,7 +135,10 @@ class UserSession(BaseModel):
 
         now = datetime.now()
 
-        session.update(date_accessed=now, date_closed=now)
+        # session.update(date_accessed=now, date_closed=now)
+        session.date_accessed = now
+        session.date_closed = now
+        session.save()
 
         return session
 

--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -59,7 +59,7 @@ class UserSession(database_handle.BaseModel):
         :return:
         """
 
-        now = datetime.now()
+        now = datetime.datetime.now()
 
         session = cls.create(
             user_id = user,
@@ -80,7 +80,7 @@ class UserSession(database_handle.BaseModel):
         """
         session = cls.get(user_id=user, date_closed=None)
 
-        now = datetime.now()
+        now = datetime.datetime.now()
 
         #session.update(date_accessed = now)
         session.date_accessed = now
@@ -97,7 +97,7 @@ class UserSession(database_handle.BaseModel):
         """
         session = cls.get(user_id=user, date_closed=None)
 
-        now = datetime.now()
+        now = datetime.datetime.now()
 
         # session.update(date_accessed=now, date_closed=now)
         session.date_accessed = now

--- a/chalice/chalicelib/routes.py
+++ b/chalice/chalicelib/routes.py
@@ -10,7 +10,7 @@ from chalicelib import models
 def index():
     load_route_services()
     app.log.debug('INDEX CONTEXT = ' + str(app.lambda_context))
-    return Response(**app.templates.render_authorized_route_template('/', app.current_request))
+    return Response(**app.templates.render_authorized_template('logged_in.html', app.current_request))
 
 
 @app.route('/overview')
@@ -21,8 +21,8 @@ def overview_dashboard():
             models.ProductTeam.select().where(models.ProductTeam.active == True)
         )
         app.log.debug("Criteria stats: " + app.utilities.to_json(criteria_stats))
-        response = app.templates.render_authorized_route_template(
-            '/overview',
+        response = app.templates.render_authorized_template(
+            'overview.html',
             app.current_request,
             {"criteria_summary": criteria_stats}
         )
@@ -38,8 +38,8 @@ def overview_dashboard():
 def team_list():
     load_route_services()
     try:
-        response = app.templates.render_authorized_route_template(
-            '/team',
+        response = app.templates.render_authorized_template(
+            'teams.html',
             app.current_request,
             {
                 'teams': [
@@ -63,8 +63,8 @@ def team_dashboard(id):
         team = models.ProductTeam.get_by_id(team_id)
         criteria_stats = models.ProductTeam.get_criteria_stats([team])
         app.log.debug("Criteria stats: " + app.utilities.to_json(criteria_stats))
-        response = app.templates.render_authorized_route_template(
-            '/team/{id}/dashboard',
+        response = app.templates.render_authorized_template(
+            'team_dashboard.html',
             app.current_request,
             {
                 "team": team.serialize(),
@@ -93,8 +93,8 @@ def resource_details(id):
         compliance = (
             models.ResourceCompliance.select().join(models.AuditResource).where(models.AuditResource.id == resource.id)
         ).get()
-        response = app.templates.render_authorized_route_template(
-            '/resource/{id}',
+        response = app.templates.render_authorized_template(
+            'resource_details.html',
             app.current_request,
             {
                 "team": models.ProductTeam.get_by_id(account.product_team_id).serialize(),
@@ -116,20 +116,20 @@ def resource_details(id):
 @app.route('/logout')
 def logout():
     load_route_services()
-    return Response(**app.templates.render_authorized_route_template('/logout', app.current_request))
+    return Response(**app.templates.render_authorized_template('logged_out.html', app.current_request))
 
 
 @app.route('/audit')
 def audit_list():
     load_route_services()
     # TODO: Base template needs anchor to this route
-    return Response(**app.templates.render_authorized_route_template('/audit', app.current_request))
+    return Response(**app.templates.render_authorized_template('audit_list.html', app.current_request))
 
 
 @app.route('/audit/{id}')
 def audit_report(id):
     load_route_services()
-    return Response(**app.templates.render_authorized_route_template('/audit/{id}', app.current_request))
+    return Response(**app.templates.render_authorized_template('audit.html', app.current_request))
 
 
 # ASSET RENDERERS

--- a/chalice/chalicelib/template_handler.py
+++ b/chalice/chalicelib/template_handler.py
@@ -156,8 +156,8 @@ class TemplateHandler:
             # TODO add permission control
             login_data = self.auth.get_login_data()
 
+            # Successfully authenticated and permissioned user
             if logged_in:
-                # Successfully authenticated and permissioned user
 
                 data.update(login_data)
 
@@ -169,18 +169,16 @@ class TemplateHandler:
                 data["logout_url"] = f"{root_path}/logout"
                 data["menu"] = self.get_menu(root_path)
 
-
-            elif not login_data['is_registered']:
-                # Check for successful auth but non-registered user
+            # Check for successful auth but non-registered user
+            elif (('is_registered' not in login_data)
+                  or (not login_data['is_registered'])):
 
                 template_file = 'request_access.html'
 
                 status_code = 403
 
-
+            # Back to logged out
             else:
-                # Back to logged out
-
                 template_file = 'logged_out.html'
 
                 login_url = self.auth.get_auth_url(self.base_url + route)

--- a/chalice/chalicelib/template_handler.py
+++ b/chalice/chalicelib/template_handler.py
@@ -87,7 +87,7 @@ class TemplateHandler:
     def get_menu_active_class_modifier(self, route, test):
         return ('--active' if route == test else '')
 
-    def get_menu(self, app, root_path=""):
+    def get_menu(self, root_path=""):
 
         route = self.get_request_path()
 

--- a/chalice/chalicelib/template_handler.py
+++ b/chalice/chalicelib/template_handler.py
@@ -170,8 +170,7 @@ class TemplateHandler:
                 data["menu"] = self.get_menu(root_path)
 
             # Check for successful auth but non-registered user
-            elif (('is_registered' not in login_data)
-                  or (not login_data['is_registered'])):
+            elif login_data['authenticated'] and not login_data['is_registered']:
 
                 template_file = 'request_access.html'
 

--- a/chalice/chalicelib/template_handler.py
+++ b/chalice/chalicelib/template_handler.py
@@ -111,15 +111,15 @@ class TemplateHandler:
 
     def render_authorized_template(self, template_file, req, data={}):
 
+        headers = {
+            "Content-Type": "text/html"
+        }
+
         try:
 
             status_code = 200
 
-            route = self.get_route_path(req)
-
-            headers = {
-                "Content-Type": "text/html"
-            }
+            route = self.get_request_path()
 
             auth = self.get_auth_handler()
 

--- a/chalice/chalicelib/template_handler.py
+++ b/chalice/chalicelib/template_handler.py
@@ -109,13 +109,17 @@ class TemplateHandler:
             }
         ]
 
-    def render_authorized_template(self, template_file, req, data={}):
+    def render_authorized_template(self, template_file, req, data=None):
 
         headers = {
             "Content-Type": "text/html"
         }
 
         try:
+
+            # If no template data has been passed initialise an empty dict
+            if data is None:
+                data = {}
 
             status_code = 200
 
@@ -144,13 +148,13 @@ class TemplateHandler:
 
             asset_path = f"{root_path}/assets"
 
-            # if there is a user then show the requested route
-            # TODO add permission control
             if template_file == 'logged_out.html':
 
                 logged_in = False
                 headers["Set-Cookie"] = self.auth.generate_logout_header_val()
 
+            # if there is a user then show the requested route
+            # TODO add permission control
             if logged_in:
 
                 login_data = self.auth.get_login_data()
@@ -169,8 +173,8 @@ class TemplateHandler:
                 template_file = 'logged_out.html'
 
                 login_url, _ = self.auth_flow.authorization_url(
-                    prompt="select_account",
-                    hd="digital.cabinet-office.gov.uk"
+                    prompt="Select Account",
+                    hd=self.auth.email_domain
                 )
 
                 data["login_url"] = login_url

--- a/chalice/chalicelib/template_handler.py
+++ b/chalice/chalicelib/template_handler.py
@@ -27,33 +27,16 @@ class TemplateHandler:
 
         self.logged_in = False
         self.login_data = {}
-        self.route_templates = {
-            "/": "logged_in.html",
-            "/logout": "logged_out.html",
-            "/audit": "audit_list.html",
-            "/audit/{id}": "audit.html",
-            "/overview": "overview.html",
-            "/team": "teams.html",
-            "/team/{id}/dashboard": "team_dashboard.html",
-            "/resource/{id}": "resource_details.html",
-            "/test/ports_ingress_ssh": "test_evaluation.html",
-            "/test/root_mfa": "test_evaluation.html",
-            "/test/validate_iam_policy": "test_evaluation.html"
-        }
-
-    def get_route_template_file(self, route):
-        if route in self.route_templates:
-            template_file = self.route_templates[route]
-        else:
-            template_file = 'logged_in.html'
-
-        return template_file
 
     def render_template(self, file, params):
 
         template = self.get_template(file)
         body = template.render(**params)
         return body
+
+    def get_request_path(self):
+
+        return self.app.current_request.context['resourcePath']
 
     def get_template(self, file):
 
@@ -99,12 +82,14 @@ class TemplateHandler:
         self.env.filters['timestamp'] = format_datetime
 
     def is_real(self):
-        return ((self.request_url.find('localhost') == -1) and (self.request_url.find('127.0.0.1') == -1))
+        return ((self.base_url.find('localhost') == -1) and (self.base_url.find('127.0.0.1') == -1))
 
     def get_menu_active_class_modifier(self, route, test):
         return ('--active' if route == test else '')
 
-    def get_menu(app, root_path="", route="/"):
+    def get_menu(self, app, root_path=""):
+
+        route = self.get_request_path()
 
         return [
             {
@@ -124,10 +109,13 @@ class TemplateHandler:
             }
         ]
 
-    def render_authorized_route_template(self, route, req, data={}):
+    def render_authorized_template(self, template_file, req, data={}):
 
         try:
+
             status_code = 200
+
+            route = self.get_route_path(req)
 
             headers = {
                 "Content-Type": "text/html"
@@ -135,13 +123,13 @@ class TemplateHandler:
 
             auth = self.get_auth_handler()
 
-            self.request_url = auth.get_request_url(req)
+            self.base_url = auth.get_base_url(req)
 
-            self.app.log.debug('Request URL: ' + self.request_url)
+            self.app.log.debug('Base URL: ' + self.base_url)
 
             if self.is_real():
 
-                self.auth_flow = auth.get_auth_flow(self.request_url + route)
+                self.auth_flow = auth.get_auth_flow(self.base_url + route)
                 root_path = "/app"
 
                 logged_in = self.auth.try_login(req)
@@ -155,16 +143,15 @@ class TemplateHandler:
                 self.app.log.debug('Is localhost')
 
             asset_path = f"{root_path}/assets"
+
             # if there is a user then show the requested route
             # TODO add permission control
-            if route == '/logout':
+            if template_file == 'logout.html':
 
                 logged_in = False
                 headers["Set-Cookie"] = self.auth.generate_logout_header_val()
 
             if logged_in:
-
-                template_file = self.get_route_template_file(route)
 
                 login_data = self.auth.get_login_data()
                 data.update(login_data)
@@ -175,7 +162,7 @@ class TemplateHandler:
                     headers["Set-Cookie"] = self.auth.cookie
 
                 data["logout_url"] = f"{root_path}/logout"
-                data["menu"] = self.get_menu(root_path, route)
+                data["menu"] = self.get_menu(root_path)
 
             else:
 
@@ -191,7 +178,7 @@ class TemplateHandler:
                 # Redirect to homepage to login
                 if route != "/":
                     status_code = 302
-                    headers["Location"] = self.request_url
+                    headers["Location"] = self.base_url
 
             data["asset_path"] = asset_path
             data["base_path"] = root_path

--- a/chalice/chalicelib/template_handler.py
+++ b/chalice/chalicelib/template_handler.py
@@ -173,7 +173,7 @@ class TemplateHandler:
                 template_file = 'logged_out.html'
 
                 login_url, _ = self.auth_flow.authorization_url(
-                    prompt="Select Account",
+                    prompt="select_account",
                     hd=self.auth.email_domain
                 )
 

--- a/chalice/chalicelib/template_handler.py
+++ b/chalice/chalicelib/template_handler.py
@@ -180,15 +180,15 @@ class TemplateHandler:
             else:
                 template_file = 'logged_out.html'
 
-                login_url = self.auth.get_auth_url(self.base_url + route)
-
-                data["login_url"] = login_url
-
                 # Redirect to homepage to login
                 if route != "/":
                     status_code = 302
                     headers["Location"] = self.base_url
 
+            # Always populate login link in template data
+            login_url = self.auth.get_auth_url(self.base_url + route)
+
+            data["login_url"] = login_url
             data["asset_path"] = asset_path
             data["base_path"] = root_path
 

--- a/chalice/chalicelib/template_handler.py
+++ b/chalice/chalicelib/template_handler.py
@@ -146,7 +146,7 @@ class TemplateHandler:
 
             # if there is a user then show the requested route
             # TODO add permission control
-            if template_file == 'logout.html':
+            if template_file == 'logged_out.html':
 
                 logged_in = False
                 headers["Set-Cookie"] = self.auth.generate_logout_header_val()

--- a/chalice/chalicelib/templates/govuk_template.html
+++ b/chalice/chalicelib/templates/govuk_template.html
@@ -47,7 +47,13 @@
       {% if not email %}
       <p class="govuk-body-s"><a class="login" href="{{ login_url }}">Login</a></p>
       {% else %}
-      <p class="govuk-body-s">Logged in as: {{ name }} <a class="logout" href="{{ logout_url }}">Logout</a></p>
+      <p class="govuk-body-s">
+        {% if picture %}
+        <!-- TODO turn CSS styles into class -->
+        <img style="display:inline;width:1em;height:1em" src="{{ picture }}"/>
+        {% endif %}
+        Logged in as: {{ name }} <a class="logout" href="{{ logout_url }}">Logout</a>
+      </p>
       {% endif %}
     </div>
   </div>

--- a/chalice/chalicelib/templates/govuk_template.html
+++ b/chalice/chalicelib/templates/govuk_template.html
@@ -45,13 +45,13 @@
   <div class="govuk-width-container">
     <div class="csw-login-status govuk-!-margin-top-2">
       {% if not email %}
-      <p class="govuk-body-s"><a class="login" href="{{ login_url }}">Login</a></p>
+      <p class="govuk-body-s csw-login-status--text"><a class="login" href="{{ login_url }}">Login</a></p>
       {% else %}
-      <p class="govuk-body-s">
+      <p class="govuk-body-s csw-login-status--text">
         <span>Logged in as: {{ name }}</span>
         {% if picture %}
         <!-- TODO turn CSS styles into class -->
-        <img style="display:inline;width:2em;height:2em" src="{{ picture }}"/>
+        <img class="csw-login-status--avatar" src="{{ picture }}"/>
         {% endif %}
         <a class="logout" href="{{ logout_url }}">Logout</a>
       </p>

--- a/chalice/chalicelib/templates/govuk_template.html
+++ b/chalice/chalicelib/templates/govuk_template.html
@@ -48,11 +48,12 @@
       <p class="govuk-body-s"><a class="login" href="{{ login_url }}">Login</a></p>
       {% else %}
       <p class="govuk-body-s">
+        <span>Logged in as: {{ name }}</span>
         {% if picture %}
         <!-- TODO turn CSS styles into class -->
-        <img style="display:inline;width:1em;height:1em" src="{{ picture }}"/>
+        <img style="display:inline;width:2em;height:2em" src="{{ picture }}"/>
         {% endif %}
-        Logged in as: {{ name }} <a class="logout" href="{{ logout_url }}">Logout</a>
+        <a class="logout" href="{{ logout_url }}">Logout</a>
       </p>
       {% endif %}
     </div>

--- a/chalice/chalicelib/templates/not_found.html
+++ b/chalice/chalicelib/templates/not_found.html
@@ -1,0 +1,9 @@
+{% extends "govuk_template.html" %}
+{% block content %}
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper " id="main-content" role="main">
+    <h1 class="govuk-heading-l">Page not found</h1>
+    <p>The requested page was not found</p>
+  </main>
+</div>
+{% endblock %}

--- a/chalice/chalicelib/templates/request_access.html
+++ b/chalice/chalicelib/templates/request_access.html
@@ -6,10 +6,12 @@ TODO Separate implementation specific content from templates so we can keep the 
 <div class="govuk-width-container">
   <p class="govuk-main-wrapper " id="main-content" role="main">
     <h1 class="govuk-heading-l">Request access</h1>
-      <p>You have not yet been granted access to this tool.</p>
-      <p>If you think you should have access, please contact the
-          <a target="slack" href="https://gds.slack.com/messages/cyber-security-help/">#cyber-security-help</a></p>
-      Slack channel or just come and talk to us.</p>
+      <p class="govuk-body-s">You have not yet been granted access to this tool.</p>
+      <p class="govuk-body-s">
+        If you think you should have access, please contact the
+        <a target="slack" href="https://gds.slack.com/messages/cyber-security-help/">#cyber-security-help</a>
+        Slack channel or just come and talk to us.
+      </p>
   </main>
 </div>
 {% endblock %}

--- a/chalice/chalicelib/templates/request_access.html
+++ b/chalice/chalicelib/templates/request_access.html
@@ -6,8 +6,8 @@ TODO Separate implementation specific content from templates so we can keep the 
 <div class="govuk-width-container">
   <p class="govuk-main-wrapper " id="main-content" role="main">
     <h1 class="govuk-heading-l">Request access</h1>
-      <p>You do not currently been granted access to this tool.</p>
-      <p>If you think you should have access contact the
+      <p>You have not yet been granted access to this tool.</p>
+      <p>If you think you should have access, please contact the
           <a target="slack" href="https://gds.slack.com/messages/cyber-security-help/">#cyber-security-help</a></p>
       Slack channel or just come and talk to us.</p>
   </main>

--- a/chalice/chalicelib/templates/request_access.html
+++ b/chalice/chalicelib/templates/request_access.html
@@ -1,0 +1,12 @@
+{% extends "govuk_template.html" %}
+{% block content %}
+<div class="govuk-width-container">
+  <p class="govuk-main-wrapper " id="main-content" role="main">
+    <h1 class="govuk-heading-l">Request access</h1>
+      <p>You do not currently have a profile defined to access this tool.</p>
+      <p>If you think you should have access contact the
+          <a target="slack" href="https://gds.slack.com/messages/cyber-security-help/">#cyber-security-help</a></p>
+      Slack channel or just come and talk to us.</p>
+  </main>
+</div>
+{% endblock %}

--- a/chalice/chalicelib/templates/request_access.html
+++ b/chalice/chalicelib/templates/request_access.html
@@ -1,9 +1,12 @@
 {% extends "govuk_template.html" %}
 {% block content %}
+<!--
+TODO Separate implementation specific content from templates so we can keep the open code clean
+-->
 <div class="govuk-width-container">
   <p class="govuk-main-wrapper " id="main-content" role="main">
     <h1 class="govuk-heading-l">Request access</h1>
-      <p>You do not currently have a profile defined to access this tool.</p>
+      <p>You do not currently been granted access to this tool.</p>
       <p>If you think you should have access contact the
           <a target="slack" href="https://gds.slack.com/messages/cyber-security-help/">#cyber-security-help</a></p>
       Slack channel or just come and talk to us.</p>

--- a/chalice/chalicelib/test_auth.py
+++ b/chalice/chalicelib/test_auth.py
@@ -1,0 +1,116 @@
+import unittest
+import datetime
+import os
+from chalice import Chalice
+from chalicelib.auth import AuthHandler
+import google_auth_oauthlib.flow
+
+class TestAuthHandler(unittest.TestCase):
+    """
+    Unit tests for the AuthHandler class
+    """
+
+    def setUp(self):
+        """
+        """
+        os.environ['CSW_ENV'] = 'test'
+        self.app = Chalice("test")
+        self.auth = AuthHandler(self.app)
+
+    def test_init_success(self):
+        """
+        test that initialization works
+        """
+
+        self.assertIsInstance(
+            self.auth, AuthHandler
+        )
+
+        self.assertIsNone(
+            self.auth.flow
+        )
+
+        self.assertIsInstance(
+            self.auth.token_algorithm,
+            str
+        )
+
+        self.assertIsInstance(
+            self.auth.cookie_expiration,
+            datetime.timedelta
+        )
+
+        self.assertIsInstance(
+            self.auth.email_domain,
+            str
+        )
+
+        self.assertEqual(
+            len(self.auth.scopes),
+            3
+        )
+
+        self.assertIsNone(
+            self.auth.cookie
+        )
+
+        self.assertFalse(
+            self.auth.logged_in
+        )
+
+        self.assertDictEqual(
+            self.auth.login_data,
+            {}
+        )
+
+    def test_init_failure(self):
+        """
+        test that not passing Chalice app object raises a type error
+        """
+        self.assertRaises(TypeError, AuthHandler)
+
+    # TODO figure out how to test get_params
+
+    def test_get_auth_flow(self):
+        """
+        test creating the OAuth flow object
+        TODO resolve pip requirements to remove deprecation warnings - CT-341
+        """
+        flow = self.auth.get_auth_flow("https://example.com")
+        self.assertIsInstance(
+            flow,
+            google_auth_oauthlib.flow.Flow
+        )
+
+    def test_get_request_url(self):
+        """
+        Test the url generated from the request matches
+        """
+
+        # Create an example object to mock the request object
+        class TestRequest:
+            headers = {}
+
+        # Set request header values
+        protocol = "https"
+        domain = "example.com"
+
+        # Create mock request instance
+        test_request = TestRequest()
+        test_request.headers = {
+            "X-Forwarded-Proto": protocol,
+            "Host": domain
+        }
+
+        # Call the method
+        url = self.auth.get_request_url(test_request)
+
+        # Check the method returns the manually created url.
+        self.assertEqual(
+            url,
+            protocol+"://"+domain+"/app"
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Login status was being retained by re-used lambdas: CT-298

The login was open to anyone on our email domain and is now restricted to known users: CT-136

Two new models have been added User and UserSession. You can destroy and recreate your env or just run the following to add the new tables: 
`aws-vault exec cst-test -- aws lambda invoke --function-name csw-[env]-database_create_tables --payload '{"Tables":["User", "UserSession"]}' /tmp/lambda.out`

To create a user fill in the blanks and run the following:
`aws lambda invoke --function-name csw-[env]-database_create_item --payload '{"Model":"User","Params":{"email": "[email@address]", "name": "[Firstname Surname]", "active": true}}' /tmp/lambda.out` to create a user. 

The template handler used to be called with the route path on method `render_authorized_route_template`. 
it is now called with the template file name using method `render_authorized_template` 