### PR TITLE
CT-349 Turn issue backgrounds grey/white where the count is 0

### DIFF
--- a/build/csw_components/_5cols.scss
+++ b/build/csw_components/_5cols.scss
@@ -153,6 +153,12 @@
 
 }
 
+.govuk-tag__fixed-width--nonefailed {
+    @extend .govuk-tag__fixed-width;
+    background-color: govuk-colour("grey-1");
+
+}
+
 .govuk-tag__fixed-width--issues {
     @extend .govuk-tag__fixed-width;
     background-color: govuk-colour("purple");

--- a/build/csw_components/_5cols.scss
+++ b/build/csw_components/_5cols.scss
@@ -153,7 +153,7 @@
 
 }
 
-.govuk-tag__fixed-width--nonefailed {
+.govuk-tag__fixed-width--not-applicable {
     @extend .govuk-tag__fixed-width;
     background-color: govuk-colour("grey-1");
 

--- a/chalice/chalicelib/templates/components/check_results.html
+++ b/chalice/chalicelib/templates/components/check_results.html
@@ -19,11 +19,7 @@
                     <th class="govuk-table__header">{{ team_summary.product_team.team_name }}</th>
                     <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--all">{{ item.resources }}</strong></td>
                     <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--passed">{{ item.passed + item.ignored }}</strong></td>
-                    {% if item.failed %}
-                        <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--failed">{{ item.failed }}</strong></td>
-                    {% else %}
-                        <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--nonefailed">{{ item.failed }}</strong></td>
-                    {% endif %}
+                    <td class="govuk-table__cell--tag-fixed-centred"><strong class="{{'govuk-tag__fixed-width--failed' if (item.failed > 0) else 'govuk-tag__fixed-width--not-applicable'}}">{{ item.failed }}</strong></td>
 
                 </tr>
                 {% endfor %}
@@ -33,11 +29,7 @@
                     <td class="govuk-table__cell">{{ account_summary.account_subscription.account_name }}</td>
                     <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--all">{{ item.resources }}</strong></td>
                     <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--passed">{{ item.passed + item.ignored }}</strong></td>
-                    {% if item.failed %}
-                        <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--failed">{{ item.failed }}</strong></td>
-                    {% else %}
-                        <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--nonefailed">{{ item.failed }}</strong></td>
-                    {% endif %}
+                    <td class="govuk-table__cell--tag-fixed-centred"><strong class="{{'govuk-tag__fixed-width--failed' if (item.failed > 0) else 'govuk-tag__fixed-width--not-applicable'}}">{{ item.failed }}</strong></td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/chalice/chalicelib/templates/components/check_results.html
+++ b/chalice/chalicelib/templates/components/check_results.html
@@ -22,7 +22,7 @@
                     {% if item.failed %}
                         <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--failed">{{ item.failed }}</strong></td>
                     {% else %}
-                        <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--passed">{{ item.failed }}</strong></td>
+                        <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--nonefailed">{{ item.failed }}</strong></td>
                     {% endif %}
 
                 </tr>
@@ -36,7 +36,7 @@
                     {% if item.failed %}
                         <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--failed">{{ item.failed }}</strong></td>
                     {% else %}
-                        <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--passed">{{ item.failed }}</strong></td>
+                        <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--nonefailed">{{ item.failed }}</strong></td>
                     {% endif %}
                 </tr>
                 {% endfor %}

--- a/chalice/chalicelib/templates/components/check_results.html
+++ b/chalice/chalicelib/templates/components/check_results.html
@@ -19,7 +19,12 @@
                     <th class="govuk-table__header">{{ team_summary.product_team.team_name }}</th>
                     <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--all">{{ item.resources }}</strong></td>
                     <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--passed">{{ item.passed + item.ignored }}</strong></td>
-                    <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--failed">{{ item.failed }}</strong></td>
+                    {% if item.failed %}
+                        <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--failed">{{ item.failed }}</strong></td>
+                    {% else %}
+                        <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--passed">{{ item.failed }}</strong></td>
+                    {% endif %}
+
                 </tr>
                 {% endfor %}
                 {% for account_summary in criterion_summary.account_subscriptions %}
@@ -28,7 +33,11 @@
                     <td class="govuk-table__cell">{{ account_summary.account_subscription.account_name }}</td>
                     <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--all">{{ item.resources }}</strong></td>
                     <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--passed">{{ item.passed + item.ignored }}</strong></td>
-                    <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--failed">{{ item.failed }}</strong></td>
+                    {% if item.failed %}
+                        <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--failed">{{ item.failed }}</strong></td>
+                    {% else %}
+                        <td class="govuk-table__cell--tag-fixed-centred"><strong class="govuk-tag__fixed-width--passed">{{ item.failed }}</strong></td>
+                    {% endif %}
                 </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
A couple of lines.

Quick overview of changes:

* Created a new css colour component using `govuk-colour("grey-1")`
* Used an `{% if %}` in the `check_results` template to check if `item.failed` is nonzero, and use the either the `--failed` or `--nonefailed` colour accordingly

Here's a preview:

<img width="397" alt="screen shot 2018-12-10 at 3 52 50 pm" src="https://user-images.githubusercontent.com/25902330/49744043-eb20fd80-fc93-11e8-99ef-fc67300e327f.png">
