### PR TITLE
Fixed the method in the IAM client for list_roles

### DIFF
--- a/chalice/chalicelib/aws/gds_iam_client.py
+++ b/chalice/chalicelib/aws/gds_iam_client.py
@@ -17,7 +17,7 @@ class GdsIamClient(GdsAwsClient):
     def list_roles(self, session):
 
         iam = self.get_boto3_session_client('iam', session)
-        response = iam.list_users()
+        response = iam.list_roles()
 
         return response['Roles']
 


### PR DESCRIPTION
It wasn't used so far so this change won't break anything, but it
wouldn't have worked in its current state (list_users doesn't output a
dictionary with a 'Roles' key). Hopefully I'll be using this method
soon.