### PR TITLE
Fixed the method in the IAM client for list_roles

### DIFF
--- a/chalice/chalicelib/aws/gds_iam_client.py
+++ b/chalice/chalicelib/aws/gds_iam_client.py
@@ -17,7 +17,7 @@ class GdsIamClient(GdsAwsClient):
     def list_roles(self, session):
 
         iam = self.get_boto3_session_client('iam', session)
-        response = iam.list_users()
+        response = iam.list_roles()
 
         return response['Roles']
 

--- a/chalice/chalicelib/aws/gds_iam_client.py
+++ b/chalice/chalicelib/aws/gds_iam_client.py
@@ -7,24 +7,24 @@ class GdsIamClient(GdsAwsClient):
 
     resource_type = "AWS::IAM::*"
 
+    def __init__(self):
+        self.iam = self.get_boto3_session_client('iam', session) 
+
     def list_users(self, session):
 
-        iam = self.get_boto3_session_client('iam', session)
-        response = iam.list_users()
+        response = self.iam.list_users()
 
         return response['Users']
 
     def list_roles(self, session):
 
-        iam = self.get_boto3_session_client('iam', session)
-        response = iam.list_roles()
+        response = self.iam.list_roles()
 
         return response['Roles']
 
     def get_role_policy(self, session, role_name, policy_name):
 
-        iam = self.get_boto3_session_client('iam', session)
-        response = iam.get_role_policy(
+        response = self.iam.get_role_policy(
             RoleName=role_name,
             PolicyName=policy_name
         )


### PR DESCRIPTION
It wasn't used so far so this change won't break anything, but it
wouldn't have worked in its current state (list_users doesn't output a
dictionary with a 'Roles' key). Hopefully I'll be using this method
soon.