### PR TITLE
Added more detail to the translate test for the egress restriction check

### DIFF
--- a/chalice/tests/chalicelib/criteria/test_aws_ec2_egress_restriction.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_ec2_egress_restriction.py
@@ -48,17 +48,21 @@ class TestUnrestrictedEgressSecurityGroups(CriteriaSubclassTestCaseMixin, TestCa
         # output value
         for case in EGRESS_RESTRICTION:
             for group in EGRESS_RESTRICTION[case]['SecurityGroups']:
-                translation = self.subclass.translate(group)
-                self.assertEqual(
-                    translation['resource_id'],
-                    group['GroupId'],
-                    msg='The resource ID does not match the Security Group ID.'
-                )
-                self.assertEqual(
-                    translation['resource_name'],
-                    group['GroupName'],
-                    msg='The resource name does not match the Security Group name.'
-                )
+                with self.subTest():
+                    translation = self.subclass.translate(group)
+                    self.assertIsInstance(translation, dict, msg="The output of the translate method is not a dict.")
+                    self.assertIn("resource_id", translation, msg="The key 'resource_id' was not in the output of the translate method.")
+                    self.assertIn("resource_name", translation, msg="The key 'resource_name' was not in the output of the translate method.")
+                    self.assertEqual(
+                        translation['resource_id'],
+                        group['GroupId'],
+                        msg='The resource ID does not match the Security Group ID.'
+                    )
+                    self.assertEqual(
+                        translation['resource_name'],
+                        group['GroupName'],
+                        msg='The resource name does not match the Security Group name.'
+                    )
 
     def test_evaluate_pass(self):
         """


### PR DESCRIPTION
Added 3 assertions:
- Checked if the `translate` outputs a dictionary
- Checked if the key `resource_id` is in the output of translate
- Checked if the key `resource_name` is in the output of translate

Along with that, I placed all of the assertions within a subTest so that they run on each case in the test data (both pass and fail, regardless of whether the assertion fails on the first iteration).

_This pull request is brought to you by the "We iterate regularly to reduce our risk" metric, with an aim to reduce the size (and increase the frequency) of pull requests._
