### PR TITLE
Remove Google OAuth plus.me scope from scope request following Google…

### DIFF
--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -39,7 +39,6 @@ class AuthHandler:
 
         self.scopes = [
             "https://www.googleapis.com/auth/userinfo.profile",
-            "https://www.googleapis.com/auth/plus.me",
             "https://www.googleapis.com/auth/userinfo.email"
         ]
 
@@ -282,6 +281,7 @@ class AuthHandler:
 
         # Update closed date on database UserSession
         try:
+            self.app.log.debug("Close session for user: "+self.user['email'])
             db_user = models.User.find_active_by_email(self.user['email'])
             models.UserSession.close(db_user)
         except Exception as error:


### PR DESCRIPTION
… deprecation.

At the moment the login is failing because we're requesting an OAuth scope Google have removed. 