### PR TITLE
Implement resource_persistent_id field in audit_resource which should survive re-terraforming

### DIFF
--- a/build/sql/definition/00006.sql
+++ b/build/sql/definition/00006.sql
@@ -1,0 +1,8 @@
+-- Add an identifier attribute to store
+ALTER TABLE public.audit_resource
+ADD COLUMN resource_persistent_id VARCHAR(200);
+
+-- Add a non-unique index to the identifier attribute
+-- The LOWER function should not be necessary since the ids are created programmatically
+-- it should protect against us correcting case changes like Cloudtrail to CloudTrail.
+CREATE INDEX IF NOT EXISTS audit_resource_resource_persisitent_id ON public.audit_resource ((LOWER(resource_persistent_id)));

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -218,7 +218,7 @@ def account_evaluate_criteria(event):
 
     except Exception as err:
         #app.log.error(str(err))
-        app.utilities.log_typed_exception(app.log.error, err)
+        app.log.error(app.utilities.get_typed_exception(err))
     return status
 
 

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -178,7 +178,6 @@ def account_evaluate_criteria(event):
                                 params = params
                             )
 
-                            app.log.debug(app.utilities.to_json(audit_resource_item))
 
                             # create an audit_resource record
                             audit_resource = models.AuditResource.create(**audit_resource_item)
@@ -186,6 +185,11 @@ def account_evaluate_criteria(event):
                             # populate foreign key for compliance record
                             compliance["audit_resource_id"] = audit_resource
                             api_response_item["resource_compliance"] = compliance
+
+                            # temporary measure to provide resource name and id to summarize
+                            api_response_item['resource_name'] = audit_resource_item['resource_name']
+                            api_response_item['resource_id'] = audit_resource_item['resource_id']
+
                             resource_compliance = models.ResourceCompliance.create(**compliance)  # TODO: unecessary assignment?
                         summary = check.summarize(data, summary)
                 app.log.debug(app.utilities.to_json(summary))

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -211,7 +211,8 @@ def account_evaluate_criteria(event):
 
 
     except Exception as err:
-        app.log.error(str(err))
+        #app.log.error(str(err))
+        app.utilities.log_typed_exception(app.log.error, err)
     return status
 
 

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -178,6 +178,8 @@ def account_evaluate_criteria(event):
                                 params = params
                             )
 
+                            app.log.debug(app.utilities.to_json(audit_resource))
+
                             # create an audit_resource record
                             audit_resource = models.AuditResource.create(**audit_resource_item)
 

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -178,7 +178,7 @@ def account_evaluate_criteria(event):
                                 params = params
                             )
 
-                            app.log.debug(app.utilities.to_json(audit_resource))
+                            app.log.debug(app.utilities.to_json(audit_resource_item))
 
                             # create an audit_resource record
                             audit_resource = models.AuditResource.create(**audit_resource_item)

--- a/chalice/chalicelib/criteria/criteria_default.py
+++ b/chalice/chalicelib/criteria/criteria_default.py
@@ -56,10 +56,16 @@ class CriteriaDefault():
         :param item:
         :return:
         """
+
+        # aim to use the resource name but fall back to the id if not defined
+        name = item.get('resource_name', '')
+        if name == '':
+            name = item.get('resource_id', '')
+
         return (self.resource_type + "::"
                 + item.get('region','') + "::"
                 + str(audit.account_subscription_id.account_id) + "::"
-                + item.get('resource_name',''))
+                + name)
 
     def build_evaluation(
         self, resource_id, compliance_type, event, resource_type,

--- a/chalice/chalicelib/criteria/criteria_default.py
+++ b/chalice/chalicelib/criteria/criteria_default.py
@@ -58,8 +58,9 @@ class CriteriaDefault():
         """
 
         # aim to use the resource name but fall back to the id if not defined
-        name = item.get('resource_name', '')
-        if name == '':
+        if 'resource_name' in item:
+            name = item.get('resource_name', '')
+        else:
             name = item.get('resource_id', '')
 
         return (self.resource_type + "::"

--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -753,12 +753,12 @@ class AuditResource(database_handle.BaseModel):
     region = peewee.CharField(null=True)
     resource_id = peewee.CharField()
     resource_name = peewee.CharField(null=True)
+    resource_persistent_id = peewee.CharField(null=True)
     resource_data = peewee.TextField()
     date_evaluated = peewee.DateTimeField(default=datetime.datetime.now)
 
     class Meta:
         table_name = "audit_resource"
-
 
 class ResourceCompliance(database_handle.BaseModel):
     audit_resource_id = peewee.ForeignKeyField(AuditResource, backref='resource_compliance')

--- a/chalice/chalicelib/utilities.py
+++ b/chalice/chalicelib/utilities.py
@@ -56,7 +56,7 @@ class Utilities():
 
         return ClientClass
 
-    def log_typed_exception(output_to_log, err):
+    def log_typed_exception(self, output_to_log, err):
         if type(err).__module__ in ['__main__', 'builtins']:
             error_message = "{}: {}".format(type(err).__name__, err)
         else:

--- a/chalice/chalicelib/utilities.py
+++ b/chalice/chalicelib/utilities.py
@@ -55,3 +55,10 @@ class Utilities():
         ClientClass = getattr(importlib.import_module(module_name), class_name)
 
         return ClientClass
+
+    def log_typed_exception(output_to_log, err):
+        if type(err).__module__ in ['__main__', 'builtins']:
+            error_message = "{}: {}".format(type(err).__name__, err)
+        else:
+            error_message = "{}.{}: {}".format(type(err).__module__, type(err).__name__, err)
+        output_to_log(error_message)

--- a/chalice/chalicelib/utilities.py
+++ b/chalice/chalicelib/utilities.py
@@ -56,9 +56,9 @@ class Utilities():
 
         return ClientClass
 
-    def log_typed_exception(self, output_to_log, err):
+    def get_typed_exception(self, err):
         if type(err).__module__ in ['__main__', 'builtins']:
             error_message = "{}: {}".format(type(err).__name__, err)
         else:
             error_message = "{}.{}: {}".format(type(err).__module__, type(err).__name__, err)
-        output_to_log(error_message)
+        return error_message


### PR DESCRIPTION
I've added a method to the utilities class to log the type and module of an exception with the exception string so it's more helpful. I've had to add the resource name and id temporarily to the raw data for the summarise method but this is fixed properly in the next branch (any_checks)