### PR TITLE
Add "any" | "all" option to check classes so we can have checks which pass when any single resource passes. 

### DIFF
--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -203,11 +203,11 @@ def account_evaluate_criteria(event):
 
                                 # populate foreign key for compliance record
                                 compliance["audit_resource_id"] = audit_resource
-                                api_response_item["resource_compliance"] = compliance
+                                audit_resource_item["resource_compliance"] = compliance
 
                                 resource_compliance = models.ResourceCompliance.create(**compliance)  # TODO: unecessary assignment?
                                 evaluated.append(audit_resource_item)
-                        summary = check.summarize(data, summary)
+                        summary = check.summarize(evaluated, summary)
                 app.log.debug(app.utilities.to_json(summary))
                 audit_criterion.resources = summary['all']['display_stat']
                 audit_criterion.tested = summary['applicable']['display_stat']

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -252,6 +252,7 @@ def audit_evaluated_metric(event):
             if audit_criteria_data['processed']:
                 audit.criteria_processed += 1
 
+            # Use check_passed status from evaluate lambda.
             if audit_criteria_data['check_passed']:
                 audit.criteria_passed += 1
             else:

--- a/chalice/chalicelib/criteria/aws_iam_roles_with_trust_relationship.py
+++ b/chalice/chalicelib/criteria/aws_iam_roles_with_trust_relationship.py
@@ -12,6 +12,8 @@ class AwsIamRolesWithTrustRelationship(CriteriaDefault):
 
     active = True
 
+    aggregation_type = "any"
+
     ClientClass = GdsIamClient
 
     resource_type = "AWS::IAM::Role"

--- a/chalice/chalicelib/criteria/criteria_default.py
+++ b/chalice/chalicelib/criteria/criteria_default.py
@@ -9,6 +9,16 @@ class CriteriaDefault():
 
     active = False
 
+    """
+    aggregation_type = "all" | "any"
+    All (default) means that all resources have to pass for the check to pass
+    and failed resources are recorded as part of the audit results
+
+    Any means that if any individual resource passes then the check passes
+    and individual failed resources are not recorded as part of the audit results
+    """
+    aggregation_type = "all"
+
     resources = dict()
 
     resource_type = "AWS::*::*"
@@ -27,6 +37,9 @@ class CriteriaDefault():
 
     def get_session(self, account="default", role=""):
         return self.client.get_session(account, role)
+
+    def get_aggregation_type(self):
+        return self.aggregation_type
 
     def describe(self):
         return {


### PR DESCRIPTION
This is primarily for the IAM "At least one role trusts a user from gds-users" check but there are other use-cases where any compliant resource can be a pass. 