### PR TITLE
S3 versioning

### DIFF
--- a/chalice/chalicelib/aws/gds_s3_client.py
+++ b/chalice/chalicelib/aws/gds_s3_client.py
@@ -28,3 +28,8 @@ class GdsS3Client(GdsAwsClient):
             policy = str(exception)
 
         return policy
+
+    def get_bucket_versioning(self, session, bucket_name):
+
+        s3 = self.get_boto3_session_client('s3', session)
+        return s3.get_bucket_versioning(Bucket=bucket_name)

--- a/chalice/chalicelib/aws/gds_s3_client.py
+++ b/chalice/chalicelib/aws/gds_s3_client.py
@@ -35,6 +35,6 @@ class GdsS3Client(GdsAwsClient):
         try:
             versioning = s3.get_bucket_versioning(Bucket=bucket_name)
         except Exception as e:  # Usually a botocore.exceptions.ClientError - Access Denied
-            versioning = str(e)
+            versioning = {"csw_access_denied_error": str(e)}
 
         return versioning

--- a/chalice/chalicelib/aws/gds_s3_client.py
+++ b/chalice/chalicelib/aws/gds_s3_client.py
@@ -32,9 +32,4 @@ class GdsS3Client(GdsAwsClient):
     def get_bucket_versioning(self, session, bucket_name):
 
         s3 = self.get_boto3_session_client('s3', session)
-        try:
-            versioning = s3.get_bucket_versioning(Bucket=bucket_name)
-        except Exception as e:  # Usually a botocore.exceptions.ClientError - Access Denied
-            versioning = {"csw_access_denied_error": str(e)}
-
-        return versioning
+        return s3.get_bucket_versioning(Bucket=bucket_name)

--- a/chalice/chalicelib/aws/gds_s3_client.py
+++ b/chalice/chalicelib/aws/gds_s3_client.py
@@ -32,4 +32,9 @@ class GdsS3Client(GdsAwsClient):
     def get_bucket_versioning(self, session, bucket_name):
 
         s3 = self.get_boto3_session_client('s3', session)
-        return s3.get_bucket_versioning(Bucket=bucket_name)
+        try:
+            versioning = s3.get_bucket_versioning(Bucket=bucket_name)
+        except Exception as e:  # Usually a botocore.exceptions.ClientError - Access Denied
+            versioning = str(e)
+
+        return versioning

--- a/chalice/chalicelib/criteria/aws_s3_versioning.py
+++ b/chalice/chalicelib/criteria/aws_s3_versioning.py
@@ -40,8 +40,8 @@ class AwsS3Versioning(CriteriaDefault):
 
     def translate(self, data):
         item = {
-            "resource_id": data.get("Name", ""),
-            "resource_name": "arn:aws:s3:::" + data.get("Name", "")
+            "resource_id": "arn:aws:s3:::" + data.get("Name", ""),
+            "resource_name": data.get("Name", "")
         }
 
         return item

--- a/chalice/chalicelib/criteria/aws_s3_versioning.py
+++ b/chalice/chalicelib/criteria/aws_s3_versioning.py
@@ -48,7 +48,7 @@ class AwsS3Versioning(CriteriaDefault):
 
     def evaluate(self, event, bucket, whitelist):
         log_string = ""
-        if "Status" in bucket["Versioning"]:
+        if isinstance(bucket["Versioning"], dict) and "Status" in bucket["Versioning"]:
             if bucket["Versioning"]["Status"] == "Enabled":
                 compliance_type = "COMPLIANT"
                 log_string = "Bucket is found to be compliant."
@@ -56,7 +56,11 @@ class AwsS3Versioning(CriteriaDefault):
                 compliance_type = "NON_COMPLIANT"
                 self.annotation = "This S3 bucket has versioning suspended."
                 log_string = "Bucket has a Status key in its versioning data, but it does not have the 'Enabled' value."
-        else:
+        elif isinstance(bucket["Versioning"], str):
+            compliance_type = "NON_COMPLIANT"
+            self.annotation = "CSW was denied access to the versioning data of this bucket."
+            # how_do_i_fix_it should be different here. Figure this out.
+        else:  # here, bucket["Versioning"] is a dict, but without a Status key - as long as get_data works correctly...
             compliance_type = "NON_COMPLIANT"
             self.annotation = "This S3 bucket does not have versioning enabled."
             log_string = "Bucket does not have a Status key in its versioning data, implying it is not enabled."

--- a/chalice/chalicelib/criteria/aws_s3_versioning.py
+++ b/chalice/chalicelib/criteria/aws_s3_versioning.py
@@ -46,7 +46,7 @@ class AwsS3Versioning(CriteriaDefault):
 
         return item
 
-    def evaluate(self, event, bucket, whitelist):
+    def evaluate(self, event, bucket, whitelist=[]):
         log_string = ""
         if "Status" in bucket["Versioning"]:
             if bucket["Versioning"]["Status"] == "Enabled":

--- a/chalice/chalicelib/criteria/aws_s3_versioning.py
+++ b/chalice/chalicelib/criteria/aws_s3_versioning.py
@@ -46,5 +46,14 @@ class AwsS3Versioning(CriteriaDefault):
 
         return item
 
-    def evaluate(self):
-        pass
+    def evaluate(self, event, bucket, whitelist):
+        self.annotation = ""
+        compliance_type = ""
+        evaluation = self.build_evaluation(
+            ("arn:aws:s3:::" + bucket['Name']),
+            compliance_type,
+            event,
+            self.resource_type,
+            self.annotation
+        )
+        return evaluation

--- a/chalice/chalicelib/criteria/aws_s3_versioning.py
+++ b/chalice/chalicelib/criteria/aws_s3_versioning.py
@@ -50,6 +50,7 @@ class AwsS3Versioning(CriteriaDefault):
         log_string = ""
         if "Status" in bucket["Versioning"]:
             if bucket["Versioning"]["Status"] == "Enabled":
+                self.annotation = ""
                 compliance_type = "COMPLIANT"
                 log_string = "Bucket is found to be compliant."
             else:

--- a/chalice/chalicelib/criteria/aws_s3_versioning.py
+++ b/chalice/chalicelib/criteria/aws_s3_versioning.py
@@ -3,11 +3,48 @@
 # Checks to see if an S3 bucket has versioning enabled
 
 from chalicelib.criteria.criteria_default import CriteriaDefault
+from chalicelib.aws.gds_s3_client import GdsS3Client
 
 
 class AwsS3Versioning(CriteriaDefault):
 
     active = True
+
+    ClientClass = GdsS3Client
+
+    resource_type = "AWS::S3::Bucket"
+
+    is_regional = False
+
+    title = "S3 Buckets: Bucket Versioning Enabled"
+    description = "The following S3 bucket/s has/have versioning disabled"
+    why_is_it_important = ("Versioning in S3 is a way to recover from unintended user changes and actions that might "
+                           "occur through misuse or corruption, such as ransomware infection. Each time an object "
+                           "changes, a new version of that object is created.")
+    how_do_i_fix_it = ("Enable versioning on the s3 buckets listed above. Please see the following AWS documentation "
+                       "to enable versioning for an S3 bucket:<br />"
+                       "<a href='https://docs.aws.amazon.com/AmazonS3/latest/user-guide/enable-versioning.html'>"
+                       "https://docs.aws.amazon.com/AmazonS3/latest/user-guide/enable-versioning.html</a>")
+
+    def __init__(self, app):
+        super(AwsS3Versioning, self).__init__(app)
+
+    def get_data(self, session, **kwargs):
+        self.app.log.debug("Getting a list of buckets")
+        buckets = self.client.get_bucket_list(session)
+        for bucket in buckets:
+            # Mutating items as I'm iterating over them again... Sorry
+            bucket['Versioning'] = self.client.get_bucket_versioning(session, bucket['Name'])
+
+        return buckets
+
+    def translate(self, data):
+        item = {
+            "resource_id": data.get('Name', ''),
+            "resource_name": "arn:aws:s3:::" + data.get('Name', '')
+        }
+
+        return item
 
     def evaluate(self):
         pass

--- a/chalice/chalicelib/criteria/aws_s3_versioning.py
+++ b/chalice/chalicelib/criteria/aws_s3_versioning.py
@@ -57,10 +57,6 @@ class AwsS3Versioning(CriteriaDefault):
                 compliance_type = "NON_COMPLIANT"
                 self.annotation = "This S3 bucket has versioning suspended."
                 log_string = "Bucket has a Status key in its versioning data, but it does not have the 'Enabled' value."
-        elif "csw_access_denied_error" in bucket["Versioning"]:
-            compliance_type = "NON_COMPLIANT"
-            self.annotation = "CSW was denied access to the versioning data of this bucket."
-            # how_do_i_fix_it should be different here. Figure this out.
         else:
             compliance_type = "NON_COMPLIANT"
             self.annotation = "This S3 bucket does not have versioning enabled."

--- a/chalice/chalicelib/criteria/aws_s3_versioning.py
+++ b/chalice/chalicelib/criteria/aws_s3_versioning.py
@@ -34,14 +34,14 @@ class AwsS3Versioning(CriteriaDefault):
         buckets = self.client.get_bucket_list(session)
         for bucket in buckets:
             # Mutating items as I'm iterating over them again... Sorry
-            bucket['Versioning'] = self.client.get_bucket_versioning(session, bucket['Name'])
+            bucket["Versioning"] = self.client.get_bucket_versioning(session, bucket["Name"])
 
         return buckets
 
     def translate(self, data):
         item = {
-            "resource_id": data.get('Name', ''),
-            "resource_name": "arn:aws:s3:::" + data.get('Name', '')
+            "resource_id": data.get("Name", ""),
+            "resource_name": "arn:aws:s3:::" + data.get("Name", "")
         }
 
         return item
@@ -50,7 +50,7 @@ class AwsS3Versioning(CriteriaDefault):
         self.annotation = ""
         compliance_type = ""
         evaluation = self.build_evaluation(
-            ("arn:aws:s3:::" + bucket['Name']),
+            ("arn:aws:s3:::" + bucket["Name"]),
             compliance_type,
             event,
             self.resource_type,

--- a/chalice/chalicelib/criteria/aws_s3_versioning.py
+++ b/chalice/chalicelib/criteria/aws_s3_versioning.py
@@ -48,7 +48,7 @@ class AwsS3Versioning(CriteriaDefault):
 
     def evaluate(self, event, bucket, whitelist):
         log_string = ""
-        if isinstance(bucket["Versioning"], dict) and "Status" in bucket["Versioning"]:
+        if "Status" in bucket["Versioning"]:
             if bucket["Versioning"]["Status"] == "Enabled":
                 compliance_type = "COMPLIANT"
                 log_string = "Bucket is found to be compliant."
@@ -56,11 +56,11 @@ class AwsS3Versioning(CriteriaDefault):
                 compliance_type = "NON_COMPLIANT"
                 self.annotation = "This S3 bucket has versioning suspended."
                 log_string = "Bucket has a Status key in its versioning data, but it does not have the 'Enabled' value."
-        elif isinstance(bucket["Versioning"], str):
+        elif "csw_access_denied_error" in bucket["Versioning"]:
             compliance_type = "NON_COMPLIANT"
             self.annotation = "CSW was denied access to the versioning data of this bucket."
             # how_do_i_fix_it should be different here. Figure this out.
-        else:  # here, bucket["Versioning"] is a dict, but without a Status key - as long as get_data works correctly...
+        else:
             compliance_type = "NON_COMPLIANT"
             self.annotation = "This S3 bucket does not have versioning enabled."
             log_string = "Bucket does not have a Status key in its versioning data, implying it is not enabled."

--- a/chalice/chalicelib/criteria/aws_s3_versioning.py
+++ b/chalice/chalicelib/criteria/aws_s3_versioning.py
@@ -1,0 +1,13 @@
+# AwsS3Versioning
+# extends GdsS3Client
+# Checks to see if an S3 bucket has versioning enabled
+
+from chalicelib.criteria.criteria_default import CriteriaDefault
+
+
+class AwsS3Versioning(CriteriaDefault):
+
+    active = True
+
+    def evaluate(self):
+        pass

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
@@ -75,14 +75,6 @@ class TestAwsS3Versioning(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert)
             output = self._evaluate_invariant_assertions(event, item, whitelist)
             self._evaluate_failed_status_assertions(item, output)
 
-    def test_evaluate_fail_access_denied(self):
-        event = {}
-        whitelist = {}
-        for item in self.test_data['fail_access_denied']:
-            item["Versioning"] = self.test_data_status['fail_access_denied']
-            output = self._evaluate_invariant_assertions(event, item, whitelist)
-            self._evaluate_failed_status_assertions(item, output)
-
     def test_evaluate_fail_then_pass(self):
         event = {}
         whitelist = {}

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
@@ -16,6 +16,7 @@ class TestAwsS3Versioning(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert)
         self.subclass = AwsS3Versioning(self.app)
 
     def test_init_client(self):
+        self.assertIn("get_bucket_list", dir(self.subclass.client))
         self.assertIn("get_bucket_versioning", dir(self.subclass.client))
 
     def test_get_data(self):

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
@@ -1,0 +1,14 @@
+from chalicelib.criteria.aws_s3_versioning import AwsS3Versioning
+from tests.chalicelib.criteria.test_criteria_default import (CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert)
+from tests.chalicelib.criteria.test_data import S3_VERSIONING_DATA
+
+
+class TestAwsS3Versioning(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert):
+    @classmethod
+    def setupClass(cls):
+        super(TestAwsS3Versioning, cls).setUpClass()
+        cls.test_data = S3_VERSIONING_DATA
+
+    def setUp(self):
+        super(TestAwsS3Versioning, self).setUp()
+        self.subclass = AwsS3Versioning(self.app)

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
@@ -74,3 +74,11 @@ class TestAwsS3Versioning(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert)
             item["Versioning"] = self.test_data_status['fail_with_status']
             output = self._evaluate_invariant_assertions(event, item, whitelist)
             self._evaluate_failed_status_assertions(item, output)
+
+    def test_evaluate_fail_access_denied(self):
+        event = {}
+        whitelist = {}
+        for item in self.test_data['fail_access_denied']:
+            item["Versioning"] = self.test_data_status['fail_access_denied']
+            output = self._evaluate_invariant_assertions(event, item, whitelist)
+            self._evaluate_failed_status_assertions(item, output)

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
@@ -22,9 +22,12 @@ class TestAwsS3Versioning(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert)
         for key in self.test_data:
             with self.subTest(key=key):
                 self.subclass.client.get_bucket_list = lambda session: self.test_data[key]
-                self.subclass.client.get_bucket_versioning = lambda session, bucket_name: None
+                self.subclass.client.get_bucket_versioning = lambda session, bucket_name: self.test_data_status[key]
                 item = self.subclass.get_data(None)
                 self.assertIsInstance(item, list, msg="The method must return a list of dictionaries")
+                for bucket in item:
+                    self.assertIn('Versioning', bucket, msg="The dicts within the list must have a 'Versioning' key")
+                    self.assertIsInstance(bucket['Versioning'], dict, msg="Versioning must be a dict")
 
     def test_evaluate_pass(self):
         event = {}

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
@@ -33,6 +33,7 @@ class TestAwsS3Versioning(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert)
         event = {}
         whitelist = {}
         for item in self.test_data['pass']:
+            item["Versioning"] = self.test_data_status['pass']
             output = self._evaluate_invariant_assertions(event, item, whitelist)
             self._evaluate_passed_status_assertions(item, output)
 
@@ -40,5 +41,6 @@ class TestAwsS3Versioning(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert)
         event = {}
         whitelist = {}
         for item in self.test_data['fail']:
+            item["Versioning"] = self.test_data_status['fail']
             output = self._evaluate_invariant_assertions(event, item, whitelist)
             self._evaluate_failed_status_assertions(item, output)

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
@@ -44,3 +44,11 @@ class TestAwsS3Versioning(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert)
             item["Versioning"] = self.test_data_status['fail']
             output = self._evaluate_invariant_assertions(event, item, whitelist)
             self._evaluate_failed_status_assertions(item, output)
+
+    def test_evaluate_fail_with_status(self):
+        event = {}
+        whitelist = {}
+        for item in self.test_data['fail_with_status']:
+            item["Versioning"] = self.test_data_status['fail_with_status']
+            output = self._evaluate_invariant_assertions(event, item, whitelist)
+            self._evaluate_failed_status_assertions(item, output)

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
@@ -1,6 +1,6 @@
 from chalicelib.criteria.aws_s3_versioning import AwsS3Versioning
 from tests.chalicelib.criteria.test_criteria_default import (CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert)
-from tests.chalicelib.criteria.test_data import S3_VERSIONING_DATA
+from tests.chalicelib.criteria.test_data import S3_VERSIONING_BUCKETS, S3_VERSIONING_STATUS
 
 
 class TestAwsS3Versioning(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert):
@@ -8,7 +8,8 @@ class TestAwsS3Versioning(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert)
     @classmethod
     def setUpClass(cls):
         super(TestAwsS3Versioning, cls).setUpClass()
-        cls.test_data = S3_VERSIONING_DATA
+        cls.test_data = S3_VERSIONING_BUCKETS
+        cls.test_data_status = S3_VERSIONING_STATUS
 
     def setUp(self):
         super(TestAwsS3Versioning, self).setUp()
@@ -23,4 +24,4 @@ class TestAwsS3Versioning(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert)
                 self.subclass.client.get_bucket_list = lambda session: self.test_data[key]
                 self.subclass.client.get_bucket_versioning = lambda session, bucket_name: None
                 item = self.subclass.get_data(None)
-                self.assertIsInstance(item, dict, msg="get_data does not return a dict")
+                self.assertIsInstance(item, list, msg="The method must return a list of dictionaries")

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
@@ -25,3 +25,17 @@ class TestAwsS3Versioning(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert)
                 self.subclass.client.get_bucket_versioning = lambda session, bucket_name: None
                 item = self.subclass.get_data(None)
                 self.assertIsInstance(item, list, msg="The method must return a list of dictionaries")
+
+    def test_evaluate_pass(self):
+        event = {}
+        whitelist = {}
+        for item in self.test_data['pass']:
+            output = self._evaluate_invariant_assertions(event, item, whitelist)
+            self._evaluate_passed_status_assertions(item, output)
+
+    def test_evaluate_fail(self):
+        event = {}
+        whitelist = {}
+        for item in self.test_data['fail']:
+            output = self._evaluate_invariant_assertions(event, item, whitelist)
+            self._evaluate_failed_status_assertions(item, output)

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
@@ -82,3 +82,14 @@ class TestAwsS3Versioning(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert)
             item["Versioning"] = self.test_data_status['fail_access_denied']
             output = self._evaluate_invariant_assertions(event, item, whitelist)
             self._evaluate_failed_status_assertions(item, output)
+
+    def test_evaluate_fail_then_pass(self):
+        event = {}
+        whitelist = {}
+        for item in self.test_data['fail_then_pass']:
+            item["Versioning"] = self.test_data_status["fail_then_pass"][item["Name"]]
+            output = self._evaluate_invariant_assertions(event, item, whitelist)
+            if item["Name"] == "fail_bucket":
+                self._evaluate_failed_status_assertions(item, output)
+            else:
+                self._evaluate_passed_status_assertions(item, output)

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
@@ -4,11 +4,23 @@ from tests.chalicelib.criteria.test_data import S3_VERSIONING_DATA
 
 
 class TestAwsS3Versioning(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert):
+
     @classmethod
-    def setupClass(cls):
+    def setUpClass(cls):
         super(TestAwsS3Versioning, cls).setUpClass()
         cls.test_data = S3_VERSIONING_DATA
 
     def setUp(self):
         super(TestAwsS3Versioning, self).setUp()
         self.subclass = AwsS3Versioning(self.app)
+
+    def test_init_client(self):
+        self.assertIn("get_bucket_versioning", dir(self.subclass.client))
+
+    def test_get_data(self):
+        for key in self.test_data:
+            with self.subTest(key=key):
+                self.subclass.client.get_bucket_list = lambda session: self.test_data[key]
+                self.subclass.client.get_bucket_versioning = lambda session, bucket_name: None
+                item = self.subclass.get_data(None)
+                self.assertIsInstance(item, dict, msg="get_data does not return a dict")

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_versioning.py
@@ -29,6 +29,27 @@ class TestAwsS3Versioning(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAssert)
                     self.assertIn('Versioning', bucket, msg="The dicts within the list must have a 'Versioning' key")
                     self.assertIsInstance(bucket['Versioning'], dict, msg="Versioning must be a dict")
 
+    def test_translate(self):
+        for item in self.test_data.values():
+            with self.subTest():
+                for bucket in item:
+                    translation = self.subclass.translate(bucket)
+                    self.assertIsInstance(translation, dict, msg="The output of the translate method should be a dict")
+                    self.assertIn("resource_id", translation, msg="The key 'resource_id' was not in "
+                                                                  "the output of the translate method.")
+                    self.assertIn("resource_name", translation, msg="The key 'resource_name' was not in "
+                                                                    "the output of the translate method.")
+                    self.assertEqual(
+                        translation['resource_id'],
+                        "arn:aws:s3:::" + bucket['Name'],
+                        msg="resource_id does not match the bucket ARN"
+                    )
+                    self.assertEqual(
+                        translation['resource_name'],
+                        bucket['Name'],
+                        msg="resource_name does not match the bucket name"
+                    )
+
     def test_evaluate_pass(self):
         event = {}
         whitelist = {}

--- a/chalice/tests/chalicelib/criteria/test_data.py
+++ b/chalice/tests/chalicelib/criteria/test_data.py
@@ -2069,12 +2069,6 @@ S3_VERSIONING_BUCKETS = {
             'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0, tzinfo=tzutc()),
         }
     ],
-    'fail_access_denied': [
-        {
-            'Name': 'fail_with_status_bucket',
-            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0, tzinfo=tzutc()),
-        }
-    ],
     'fail_then_pass': [
         {
             'Name': 'fail_bucket',
@@ -2131,10 +2125,6 @@ S3_VERSIONING_STATUS = {
             'RequestId': '9DA0FC9336158F68',
             'RetryAttempts': 0},
         "Status": "Suspended"
-    },
-    "fail_access_denied": {
-        "csw_access_denied_error": ("An error occurred (AccessDenied) when calling the GetBucketVersioning "
-                                    "operation: Access Denied")
     },
     "fail_then_pass": {
         "fail_bucket": {

--- a/chalice/tests/chalicelib/criteria/test_data.py
+++ b/chalice/tests/chalicelib/criteria/test_data.py
@@ -2062,6 +2062,12 @@ S3_VERSIONING_BUCKETS = {
             'Name': 'fail_bucket',
             'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0, tzinfo=tzutc()),
         }
+    ],
+    'fail_with_status': [
+        {
+            'Name': 'fail_with_status_bucket',
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0, tzinfo=tzutc()),
+        }
     ]
 }
 
@@ -2094,5 +2100,20 @@ S3_VERSIONING_STATUS = {
             'HostId': 'odVvCy13WIqsdFEcuiWpmjip5rOkS81BSAUe/i/0ZaG27SRrlnk2u3Srmk/C81vky0NjjzC1uJB=',
             'RequestId': '9DA0FC9336158F68',
             'RetryAttempts': 0}
+    },
+    "fail_with_status": {
+        'ResponseMetadata': {
+            'HTTPHeaders': {
+                'date': 'Mon, 1 Jan 2000 00:00:01 GMT',
+                'server': 'AmazonS3',
+                'transfer-encoding': 'chunked',
+                'x-amz-id-2': 'odVvCy13WIqsdFEcuiWpmjip5rOkS81BSAUe/i/0ZaG27SRrlnk2u3Srmk/C81vky0NjjzC1uJB=',
+                'x-amz-request-id': 'D937E50330DBE476'
+            },
+            'HTTPStatusCode': 200,
+            'HostId': 'odVvCy13WIqsdFEcuiWpmjip5rOkS81BSAUe/i/0ZaG27SRrlnk2u3Srmk/C81vky0NjjzC1uJB=',
+            'RequestId': '9DA0FC9336158F68',
+            'RetryAttempts': 0},
+        "Status": "Suspended"
     }
 }

--- a/chalice/tests/chalicelib/criteria/test_data.py
+++ b/chalice/tests/chalicelib/criteria/test_data.py
@@ -2074,6 +2074,16 @@ S3_VERSIONING_BUCKETS = {
             'Name': 'fail_with_status_bucket',
             'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0, tzinfo=tzutc()),
         }
+    ],
+    'fail_then_pass': [
+        {
+            'Name': 'fail_bucket',
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0, tzinfo=tzutc()),
+        },
+        {
+            'Name': 'pass_bucket',
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0, tzinfo=tzutc()),
+        }
     ]
 }
 
@@ -2125,5 +2135,36 @@ S3_VERSIONING_STATUS = {
     "fail_access_denied": {
         "csw_access_denied_error": ("An error occurred (AccessDenied) when calling the GetBucketVersioning "
                                     "operation: Access Denied")
+    },
+    "fail_then_pass": {
+        "fail_bucket": {
+            'ResponseMetadata': {
+                'HTTPHeaders': {
+                    'date': 'Mon, 1 Jan 2000 00:00:01 GMT',
+                    'server': 'AmazonS3',
+                    'transfer-encoding': 'chunked',
+                    'x-amz-id-2': 'odVvCy13WIqsdFEcuiWpmjip5rOkS81BSAUe/i/0ZaG27SRrlnk2u3Srmk/C81vky0NjjzC1uJB=',
+                    'x-amz-request-id': 'D937E50330DBE476'
+                },
+                'HTTPStatusCode': 200,
+                'HostId': 'odVvCy13WIqsdFEcuiWpmjip5rOkS81BSAUe/i/0ZaG27SRrlnk2u3Srmk/C81vky0NjjzC1uJB=',
+                'RequestId': '9DA0FC9336158F68',
+                'RetryAttempts': 0}
+        },
+        "pass_bucket": {
+            'ResponseMetadata': {
+                'HTTPHeaders': {
+                    'date': 'Mon, 1 Jan 2000 00:00:01 GMT',
+                    'server': 'AmazonS3',
+                    'transfer-encoding': 'chunked',
+                    'x-amz-id-2': 'odVvCy13WIqsdFEcuiWpmjip5rOkS81BSAUe/i/0ZaG27SRrlnk2u3Srmk/C81vky0NjjzC1uJB=',
+                    'x-amz-request-id': 'D937E50330DBE476'
+                },
+                'HTTPStatusCode': 200,
+                'HostId': 'odVvCy13WIqsdFEcuiWpmjip5rOkS81BSAUe/i/0ZaG27SRrlnk2u3Srmk/C81vky0NjjzC1uJB=',
+                'RequestId': '9DA0FC9336158F68',
+                'RetryAttempts': 0},
+            "Status": "Enabled"
+        }
     }
 }

--- a/chalice/tests/chalicelib/criteria/test_data.py
+++ b/chalice/tests/chalicelib/criteria/test_data.py
@@ -2050,7 +2050,23 @@ S3_BUCKET_POLICIES = {
              '{"Bool": {"aws:SecureTransport": "true"}}}]}')
 }
 
-S3_VERSIONING_DATA = {
-    "pass" : {},
-    "fail" : {}
+S3_VERSIONING_BUCKETS = {
+    'pass': [
+        {
+            'Name': 'pass_bucket',
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0, tzinfo=tzutc()),
+        }
+    ],
+    'fail': [
+        {
+            'Name': 'fail_bucket',
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0, tzinfo=tzutc()),
+        }
+    ]
+}
+S3_VERSIONING_STATUS = {
+    "pass": {
+        "Status":"Enabled"
+    },
+    "fail": {}
 }

--- a/chalice/tests/chalicelib/criteria/test_data.py
+++ b/chalice/tests/chalicelib/criteria/test_data.py
@@ -2068,6 +2068,12 @@ S3_VERSIONING_BUCKETS = {
             'Name': 'fail_with_status_bucket',
             'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0, tzinfo=tzutc()),
         }
+    ],
+    'fail_access_denied': [
+        {
+            'Name': 'fail_with_status_bucket',
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0, tzinfo=tzutc()),
+        }
     ]
 }
 
@@ -2115,5 +2121,9 @@ S3_VERSIONING_STATUS = {
             'RequestId': '9DA0FC9336158F68',
             'RetryAttempts': 0},
         "Status": "Suspended"
+    },
+    "fail_access_denied": {
+        "csw_access_denied_error": ("An error occurred (AccessDenied) when calling the GetBucketVersioning "
+                                    "operation: Access Denied")
     }
 }

--- a/chalice/tests/chalicelib/criteria/test_data.py
+++ b/chalice/tests/chalicelib/criteria/test_data.py
@@ -2064,9 +2064,35 @@ S3_VERSIONING_BUCKETS = {
         }
     ]
 }
+
 S3_VERSIONING_STATUS = {
     "pass": {
-        "Status":"Enabled"
+        'ResponseMetadata': {
+            'HTTPHeaders': {
+                'date': 'Mon, 1 Jan 2000 00:00:01 GMT',
+                'server': 'AmazonS3',
+                'transfer-encoding': 'chunked',
+                'x-amz-id-2': 'odVvCy13WIqsdFEcuiWpmjip5rOkS81BSAUe/i/0ZaG27SRrlnk2u3Srmk/C81vky0NjjzC1uJB=',
+                'x-amz-request-id': 'D937E50330DBE476'
+            },
+            'HTTPStatusCode': 200,
+            'HostId': 'odVvCy13WIqsdFEcuiWpmjip5rOkS81BSAUe/i/0ZaG27SRrlnk2u3Srmk/C81vky0NjjzC1uJB=',
+            'RequestId': '9DA0FC9336158F68',
+            'RetryAttempts': 0},
+        "Status": "Enabled"
     },
-    "fail": {}
+    "fail": {
+        'ResponseMetadata': {
+            'HTTPHeaders': {
+                'date': 'Mon, 1 Jan 2000 00:00:01 GMT',
+                'server': 'AmazonS3',
+                'transfer-encoding': 'chunked',
+                'x-amz-id-2': 'odVvCy13WIqsdFEcuiWpmjip5rOkS81BSAUe/i/0ZaG27SRrlnk2u3Srmk/C81vky0NjjzC1uJB=',
+                'x-amz-request-id': 'D937E50330DBE476'
+            },
+            'HTTPStatusCode': 200,
+            'HostId': 'odVvCy13WIqsdFEcuiWpmjip5rOkS81BSAUe/i/0ZaG27SRrlnk2u3Srmk/C81vky0NjjzC1uJB=',
+            'RequestId': '9DA0FC9336158F68',
+            'RetryAttempts': 0}
+    }
 }

--- a/chalice/tests/chalicelib/criteria/test_data.py
+++ b/chalice/tests/chalicelib/criteria/test_data.py
@@ -2049,3 +2049,8 @@ S3_BUCKET_POLICIES = {
              '"s3:GetObject", "Resource": "arn:aws:s3:::my_bucket/*", "Condition": '
              '{"Bool": {"aws:SecureTransport": "true"}}}]}')
 }
+
+S3_VERSIONING_DATA = {
+    "pass" : {},
+    "fail" : {}
+}


### PR DESCRIPTION
Summary of changes:

- Added a new method to the S3 client, implementing the get_bucket_versioning API call. This requires an update of the CSW client role, otherwise the check will run into access denied errors.
- Unit tests and test data added for the check
    - This includes a test for when a `COMPLIANT` resource follows a `NON_COMPLIANT` one. We found out that because we use the same instance of the criteria class when evaluating a list of resources, the `annotation` field of the instance remains after being set by a failing resource - meaning that in CloudWatch logs, a `COMPLIANT` evaluation also includes a failing annotation, which is incredibly confusing. We fixed this with the line `self.annotation = ""` when a resource passes the check. More work needs to be done to both fix this for all criteria and to test it.
- Check added for the S3 Versioning criterion.