### PR TITLE
CT-593 - Left pad AWS account ID with 0s up to 12 characters.

### DIFF
--- a/chalice/chalicelib/aws/gds_aws_client.py
+++ b/chalice/chalicelib/aws/gds_aws_client.py
@@ -34,7 +34,8 @@ class GdsAwsClient:
     # eg: 779799343306-AdminRole
     def get_session_name(self, account, role=''):
         # Force account to be a 12 character zero padded string
-        account = str(account).rjust(12, '0')
+        if account != "default":
+            account = str(account).rjust(12, '0')
         if (role == ""):
             session_name = account
         else:
@@ -142,12 +143,13 @@ class GdsAwsClient:
         '''
         try:
             # force account to be 12 character string with leading zeros.
-            account_id = str(account).rjust(12, '0')
+            if account != "default":
+                account = str(account).rjust(12, '0')
             self.app.log.debug(f"Assuming to account: {account} with role: {role}")
 
             sts = self.get_boto3_client('sts')
 
-            role_arn = f"arn:aws:iam::{account_id}:role/{role}"
+            role_arn = f"arn:aws:iam::{account}:role/{role}"
             print(f"Assume role: {role_arn}")
 
             session_name = self.get_session_name(account, role)

--- a/chalice/chalicelib/aws/gds_aws_client.py
+++ b/chalice/chalicelib/aws/gds_aws_client.py
@@ -33,6 +33,8 @@ class GdsAwsClient:
     # {account-number}-{role-name}
     # eg: 779799343306-AdminRole
     def get_session_name(self, account, role=''):
+        # Force account to be a 12 character zero padded string
+        account = str(account).rjust(12, '0')
         if (role == ""):
             session_name = account
         else:
@@ -139,6 +141,8 @@ class GdsAwsClient:
         }
         '''
         try:
+            # force account to be 12 character string with leading zeros.
+            account = str(account).rjust(12, '0')
             sts = self.get_boto3_client('sts')
 
             role_arn = f"arn:aws:iam::{account}:role/{role}"

--- a/chalice/chalicelib/aws/gds_aws_client.py
+++ b/chalice/chalicelib/aws/gds_aws_client.py
@@ -91,7 +91,7 @@ class GdsAwsClient:
         session_name = self.get_session_name(account, role)
         client_name = self.get_client_name(service_name, session_name)
 
-        session = self.get_session(session_name)
+        session = self.get_session(account, role)
         self.clients[client_name] = boto3.client(
             service_name,
             aws_access_key_id=session['AccessKeyId'],
@@ -143,6 +143,8 @@ class GdsAwsClient:
         try:
             # force account to be 12 character string with leading zeros.
             account = str(account).rjust(12, '0')
+            self.app.log.debug(f"Assuming to account: {account} with role: {role}")
+
             sts = self.get_boto3_client('sts')
 
             role_arn = f"arn:aws:iam::{account}:role/{role}"

--- a/chalice/chalicelib/aws/gds_aws_client.py
+++ b/chalice/chalicelib/aws/gds_aws_client.py
@@ -142,12 +142,12 @@ class GdsAwsClient:
         '''
         try:
             # force account to be 12 character string with leading zeros.
-            account = str(account).rjust(12, '0')
+            account_id = str(account).rjust(12, '0')
             self.app.log.debug(f"Assuming to account: {account} with role: {role}")
 
             sts = self.get_boto3_client('sts')
 
-            role_arn = f"arn:aws:iam::{account}:role/{role}"
+            role_arn = f"arn:aws:iam::{account_id}:role/{role}"
             print(f"Assume role: {role_arn}")
 
             session_name = self.get_session_name(account, role)


### PR DESCRIPTION
The verify account ID has a leading zero and without that the ARN is not recognised for the assume role. 