### PR TITLE
[CT-500] S3 HTTPS policy fix

### DIFF
--- a/chalice/chalicelib/criteria/aws_s3_secure_policy.py
+++ b/chalice/chalicelib/criteria/aws_s3_secure_policy.py
@@ -78,13 +78,6 @@ class AwsS3SecurePolicy(CriteriaDefault):
                     break
                 else:
                     secure = statement['Condition'].get('Bool', {}).get('aws:SecureTransport')
-                    if secure == "false":  # secure is either "true", "false", or None if it didn't exist
-                        # Failure: HTTPS is specifically disallowed
-                        log_string = "Bucket's policy condition explicitly disallows HTTPS"
-                        compliance_type = "NOT_COMPLIANT"
-                        self.annotation = ("This bucket's policy explicitly disallows HTTPS."
-                                           "Make sure that the aws:SecureTransport condition is set to 'true'.")
-                        break
                     if not secure:  # testing if secure is None
                         # Failure: no secure transport condition
                         log_string = "Bucket does not disallow insecure connections"

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_secure_policy.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_secure_policy.py
@@ -74,6 +74,26 @@ class TestAwsS3SecurePolicy(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAsser
             output = self._evaluate_invariant_assertions(event, item, whitelist)
             self._evaluate_passed_status_assertions(item, output)
 
+    def test_evaluate_pass_multiple_statements(self):
+        event = {}
+        whitelist = []
+        for item in self.test_data['pass_multiple_statements']:
+            policy = self.test_data_policies['pass_multiple_statements']
+            item['Policy'] = json.loads(policy)
+
+            output = self._evaluate_invariant_assertions(event, item, whitelist)
+            self._evaluate_passed_status_assertions(item, output)
+
+    def test_evaluate_fail_multiple_statements(self):
+        event = {}
+        whitelist = []
+        for item in self.test_data['fail_multiple_statements']:
+            policy = self.test_data_policies['fail_multiple_statements']
+            item['Policy'] = json.loads(policy)
+
+            output = self._evaluate_invariant_assertions(event, item, whitelist)
+            self._evaluate_failed_status_assertions(item, output)
+
     def test_evaluate_fail_secure_transport_true(self):
         event = {}
         whitelist = []

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_secure_policy.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_secure_policy.py
@@ -96,13 +96,3 @@ class TestAwsS3SecurePolicy(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAsser
             output = self._evaluate_invariant_assertions(event, item, whitelist)
             self._evaluate_failed_status_assertions(item, output)
             self.assertIn("no SecureTransport", self.subclass.annotation)
-
-    def test_evaluate_fail_only_insecure(self):
-        event = {}
-        whitelist = []
-        for item in self.test_data['fail_only_insecure']:
-            policy = self.test_data_policies['fail_only_insecure']
-            item['Policy'] = json.loads(policy)
-            output = self._evaluate_invariant_assertions(event, item, whitelist)
-            self._evaluate_failed_status_assertions(item, output)
-            self.assertIn("explicitly disallows HTTPS", self.subclass.annotation)

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_secure_policy.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_secure_policy.py
@@ -148,3 +148,14 @@ class TestAwsS3SecurePolicy(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAsser
             output = self._evaluate_invariant_assertions(event, item, whitelist)
             self._evaluate_failed_status_assertions(item, output)
             self.assertIn("no SecureTransport", self.subclass.annotation)
+
+    def test_evaluate_fail_only_partly_secure(self):
+        event = {}
+        whitelist = []
+        for item in self.test_data['fail_only_partly_secure']:
+            policy = self.test_data_policies['fail_only_partly_secure']
+            item['Policy'] = json.loads(policy)
+
+            output = self._evaluate_invariant_assertions(event, item, whitelist)
+            self._evaluate_failed_status_assertions(item, output)
+            self.assertIn("all items in", self.subclass.annotation)

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_secure_policy.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_secure_policy.py
@@ -103,6 +103,7 @@ class TestAwsS3SecurePolicy(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAsser
 
             output = self._evaluate_invariant_assertions(event, item, whitelist)
             self._evaluate_failed_status_assertions(item, output)
+            self.assertIn("misconfigured", self.subclass.annotation)
 
     def test_evaluate_fail_secure_transport_false(self):
         event = {}
@@ -113,6 +114,7 @@ class TestAwsS3SecurePolicy(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAsser
 
             output = self._evaluate_invariant_assertions(event, item, whitelist)
             self._evaluate_failed_status_assertions(item, output)
+            self.assertIn("misconfigured", self.subclass.annotation)
 
     def test_evaluate_fail_no_policy(self):
         event = {}

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_secure_policy.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_secure_policy.py
@@ -159,3 +159,14 @@ class TestAwsS3SecurePolicy(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAsser
             output = self._evaluate_invariant_assertions(event, item, whitelist)
             self._evaluate_failed_status_assertions(item, output)
             self.assertIn("all items in", self.subclass.annotation)
+
+    def test_evaluate_fail_overridden_statement(self):
+        event = {}
+        whitelist = []
+        for item in self.test_data['fail_overridden_statement']:
+            policy = self.test_data_policies['fail_overridden_statement']
+            item['Policy'] = json.loads(policy)
+
+            output = self._evaluate_invariant_assertions(event, item, whitelist)
+            self._evaluate_failed_status_assertions(item, output)
+            self.assertIn("misconfigured", self.subclass.annotation)

--- a/chalice/tests/chalicelib/criteria/test_aws_s3_secure_policy.py
+++ b/chalice/tests/chalicelib/criteria/test_aws_s3_secure_policy.py
@@ -54,22 +54,52 @@ class TestAwsS3SecurePolicy(CriteriaSubclassTestCaseMixin, TestCaseWithAttrAsser
                     msg="resource_name does not match the bucket name"
                 )
 
-    def test_evaluate_pass(self):
+    def test_evaluate_pass_secure_transport_true(self):
         event = {}
         whitelist = []
-        for item in self.test_data['pass']:
-            policy = self.test_data_policies['pass']
+        for item in self.test_data['pass_secure_transport_true']:
+            policy = self.test_data_policies['pass_secure_transport_true']
             item['Policy'] = json.loads(policy)
 
             output = self._evaluate_invariant_assertions(event, item, whitelist)
             self._evaluate_passed_status_assertions(item, output)
+
+    def test_evaluate_pass_secure_transport_false(self):
+        event = {}
+        whitelist = []
+        for item in self.test_data['pass_secure_transport_false']:
+            policy = self.test_data_policies['pass_secure_transport_false']
+            item['Policy'] = json.loads(policy)
+
+            output = self._evaluate_invariant_assertions(event, item, whitelist)
+            self._evaluate_passed_status_assertions(item, output)
+
+    def test_evaluate_fail_secure_transport_true(self):
+        event = {}
+        whitelist = []
+        for item in self.test_data['fail_secure_transport_true']:
+            policy = self.test_data_policies['fail_secure_transport_true']
+            item['Policy'] = json.loads(policy)
+
+            output = self._evaluate_invariant_assertions(event, item, whitelist)
+            self._evaluate_failed_status_assertions(item, output)
+
+    def test_evaluate_fail_secure_transport_false(self):
+        event = {}
+        whitelist = []
+        for item in self.test_data['fail_secure_transport_false']:
+            policy = self.test_data_policies['fail_secure_transport_false']
+            item['Policy'] = json.loads(policy)
+
+            output = self._evaluate_invariant_assertions(event, item, whitelist)
+            self._evaluate_failed_status_assertions(item, output)
 
     def test_evaluate_fail_no_policy(self):
         event = {}
         whitelist = []
         for item in self.test_data['fail_no_policy']:
             policy = self.test_data_policies['fail_no_policy']
-            item['Policy'] = policy  # The policy isn't valid JSON in this case
+            item['Policy'] = policy  # The policy isn't valid JSON in this case
 
             output = self._evaluate_invariant_assertions(event, item, whitelist)
             self._evaluate_failed_status_assertions(item, output)

--- a/chalice/tests/chalicelib/criteria/test_data.py
+++ b/chalice/tests/chalicelib/criteria/test_data.py
@@ -2050,6 +2050,12 @@ S3_BUCKET_POLICY_BUCKETS = {
             'Name': 'my_bucket',
             'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0)
         }
+    ],
+    'fail_only_partly_secure': [
+        {
+            'Name': 'my_bucket',
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0)
+        }
     ]
 }
 
@@ -2097,7 +2103,11 @@ S3_BUCKET_POLICIES = {
                                  '"arn:aws:s3:::my_bucket/*", "Condition": { "Bool": { "aws:SecureTransport": "false" }'
                                  ' } }, { "Sid": "YetAnotherStatement", "Effect": "Allow", "Principal": "*", "Action": '
                                  '[ "s3:PutObject", "s3:PutObjectAcl" ], "Resource": [ "arn:aws:s3:::examplebucket/*" '
-                                 '], "Condition": { "StringEquals": { "s3:x-amz-acl": [ "public-read" ] } } } ] }')
+                                 '], "Condition": { "StringEquals": { "s3:x-amz-acl": [ "public-read" ] } } } ] }'),
+    'fail_only_partly_secure': ('{"Version": "2008-10-17", "Id": "some_policy", "Statement": [{"Sid": "AddPerm", '
+                                '"Effect": "Allow", "Principal": {"AWS": "*"}, "Action": "s3:GetObject", "Resource": '
+                                '"arn:aws:s3:::my_bucket/some_folder/*", "Condition": {"Bool": {"aws:SecureTransport": '
+                                '"true"}}}]}')
 }
 
 S3_VERSIONING_BUCKETS = {

--- a/chalice/tests/chalicelib/criteria/test_data.py
+++ b/chalice/tests/chalicelib/criteria/test_data.py
@@ -2056,6 +2056,12 @@ S3_BUCKET_POLICY_BUCKETS = {
             'Name': 'my_bucket',
             'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0)
         }
+    ],
+    'fail_overridden_statement': [
+        {
+            'Name': 'my_bucket',
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0)
+        }
     ]
 }
 
@@ -2107,7 +2113,13 @@ S3_BUCKET_POLICIES = {
     'fail_only_partly_secure': ('{"Version": "2008-10-17", "Id": "some_policy", "Statement": [{"Sid": "AddPerm", '
                                 '"Effect": "Allow", "Principal": {"AWS": "*"}, "Action": "s3:GetObject", "Resource": '
                                 '"arn:aws:s3:::my_bucket/some_folder/*", "Condition": {"Bool": {"aws:SecureTransport": '
-                                '"true"}}}]}')
+                                '"true"}}}]}'),
+    'fail_overridden_statement': ('{"Version":"2012-10-17","Id":"some_policy","Statement":[{"Sid":"AddPerm","Effect":'
+                                  '"Deny","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::my_bucket/*"'
+                                  ',"Condition":{"Bool":{"aws:SecureTransport":"false"}}},{"Sid":'
+                                  '"OverridingPreviousStatement","Effect":"Allow","Principal":"*","Action":'
+                                  '"s3:GetObject","Resource":"arn:aws:s3:::my_bucket/some_folder/*","Condition":{"Bool"'
+                                  ':{"aws:SecureTransport":"false"}}}]}')
 }
 
 S3_VERSIONING_BUCKETS = {

--- a/chalice/tests/chalicelib/criteria/test_data.py
+++ b/chalice/tests/chalicelib/criteria/test_data.py
@@ -1999,25 +1999,43 @@ RDS_SECURITY_GROUPS = {'ResponseMetadata': {'HTTPHeaders': {'content-length': '2
 S3_BUCKET_POLICY_BUCKETS = {
     'fail_no_policy': [
         {
-            'Name': 'fail_no_policy_bucket',
+            'Name': 'my_bucket',
             'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
         }
     ],
     'fail_no_condition': [
         {
-            'Name': 'fail_no_condition_bucket',
+            'Name': 'my_bucket',
             'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
         }
     ],
     'fail_no_secure_condition': [
         {
-            'Name': 'fail_no_secure_condition_bucket',
+            'Name': 'my_bucket',
             'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
         }
     ],
-    'pass': [
+    'fail_secure_transport_false': [
         {
-            'Name': 'pass_bucket',
+            'Name': 'my_bucket',
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
+        }
+    ],
+    'fail_secure_transport_true': [
+        {
+            'Name': 'my_bucket',
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
+        }
+    ],
+    'pass_secure_transport_false': [
+        {
+            'Name': 'my_bucket',
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
+        }
+    ],
+    'pass_secure_transport_true': [
+        {
+            'Name': 'my_bucket',
             'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
         }
     ]
@@ -2034,10 +2052,22 @@ S3_BUCKET_POLICIES = {
                                  '"s3:GetObject", "Resource": "arn:aws:s3:::my_bucket/*", "Condition": '
                                  '{"StringLike": {"aws:Referer": ["http://www.example.com/*", '
                                  '"http://example.com/*"]}}}]}'),
-    'pass': ('{"Version": "2008-10-17", "Id": "some_policy", "Statement": [{"Sid": '
-             '"AddPerm", "Effect": "Allow", "Principal": {"AWS": "*"}, "Action": '
-             '"s3:GetObject", "Resource": "arn:aws:s3:::my_bucket/*", "Condition": '
-             '{"Bool": {"aws:SecureTransport": "true"}}}]}')
+    'fail_secure_transport_true': ('{"Version": "2008-10-17", "Id": "some_policy", "Statement": [{"Sid": '
+                                    '"AddPerm", "Effect": "Deny", "Principal": {"AWS": "*"}, "Action": '
+                                    '"s3:GetObject", "Resource": "arn:aws:s3:::my_bucket/*", "Condition": '
+                                    '{"Bool": {"aws:SecureTransport": "true"}}}]}'),
+    'fail_secure_transport_false': ('{"Version": "2008-10-17", "Id": "some_policy", "Statement": [{"Sid": '
+                                    '"AddPerm", "Effect": "Allow", "Principal": {"AWS": "*"}, "Action": '
+                                    '"s3:GetObject", "Resource": "arn:aws:s3:::my_bucket/*", "Condition": '
+                                    '{"Bool": {"aws:SecureTransport": "false"}}}]}'),
+    'pass_secure_transport_true': ('{"Version": "2008-10-17", "Id": "some_policy", "Statement": [{"Sid": '
+                                   '"AddPerm", "Effect": "Allow", "Principal": {"AWS": "*"}, "Action": '
+                                   '"s3:GetObject", "Resource": "arn:aws:s3:::my_bucket/*", "Condition": '
+                                   '{"Bool": {"aws:SecureTransport": "true"}}}]}'),
+    'pass_secure_transport_false': ('{"Version": "2008-10-17", "Id": "some_policy", "Statement": [{"Sid": '
+                                   '"AddPerm", "Effect": "Deny", "Principal": {"AWS": "*"}, "Action": '
+                                   '"s3:GetObject", "Resource": "arn:aws:s3:::my_bucket/*", "Condition": '
+                                   '{"Bool": {"aws:SecureTransport": "false"}}}]}')
 }
 
 S3_VERSIONING_BUCKETS = {

--- a/chalice/tests/chalicelib/criteria/test_data.py
+++ b/chalice/tests/chalicelib/criteria/test_data.py
@@ -2000,43 +2000,55 @@ S3_BUCKET_POLICY_BUCKETS = {
     'fail_no_policy': [
         {
             'Name': 'my_bucket',
-            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0)
         }
     ],
     'fail_no_condition': [
         {
             'Name': 'my_bucket',
-            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0)
         }
     ],
     'fail_no_secure_condition': [
         {
             'Name': 'my_bucket',
-            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0)
         }
     ],
     'fail_secure_transport_false': [
         {
             'Name': 'my_bucket',
-            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0)
         }
     ],
     'fail_secure_transport_true': [
         {
             'Name': 'my_bucket',
-            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0)
         }
     ],
     'pass_secure_transport_false': [
         {
             'Name': 'my_bucket',
-            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0)
         }
     ],
     'pass_secure_transport_true': [
         {
             'Name': 'my_bucket',
-            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0)
+        }
+    ],
+    'pass_multiple_statements': [
+        {
+            'Name': 'my_bucket',
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0)
+        }
+    ],
+    'fail_multiple_statements': [
+        {
+            'Name': 'my_bucket',
+            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0)
         }
     ]
 }
@@ -2067,7 +2079,25 @@ S3_BUCKET_POLICIES = {
     'pass_secure_transport_false': ('{"Version": "2008-10-17", "Id": "some_policy", "Statement": [{"Sid": '
                                    '"AddPerm", "Effect": "Deny", "Principal": {"AWS": "*"}, "Action": '
                                    '"s3:GetObject", "Resource": "arn:aws:s3:::my_bucket/*", "Condition": '
-                                   '{"Bool": {"aws:SecureTransport": "false"}}}]}')
+                                   '{"Bool": {"aws:SecureTransport": "false"}}}]}'),
+    'pass_multiple_statements': ('{ "Version": "2012-10-17", "Id": "some_policy", "Statement": [ { "Sid": '
+                                 '"SomeOtherStatement", "Effect": "Allow", "Principal": "*", "Action": [ '
+                                 '"s3:PutObject", "s3:PutObjectAcl" ], "Resource": [ "arn:aws:s3:::examplebucket/*" ], '
+                                 '"Condition": { "StringEquals": { "s3:x-amz-acl": [ "public-read" ] } } }, { "Sid": '
+                                 '"AddPerm", "Effect": "Deny", "Principal": "*", "Action": "s3:GetObject", "Resource": '
+                                 '"arn:aws:s3:::my_bucket/*", "Condition": { "Bool": { "aws:SecureTransport": "false" }'
+                                 ' } }, { "Sid": "YetAnotherStatement", "Effect": "Allow", "Principal": "*", "Action": '
+                                 '[ "s3:PutObject", "s3:PutObjectAcl" ], "Resource": [ "arn:aws:s3:::examplebucket/*" '
+                                 '], "Condition": { "StringEquals": { "s3:x-amz-acl": [ "public-read" ] } } } ] }'),
+    'fail_multiple_statements': ('{ "Version": "2012-10-17", "Id": "some_policy", "Statement": [ { "Sid": '
+                                 '"SomeOtherStatement", "Effect": "Allow", "Principal": "*", "Action": [ '
+                                 '"s3:PutObject", "s3:PutObjectAcl" ], "Resource": [ "arn:aws:s3:::examplebucket/*" ], '
+                                 '"Condition": { "StringEquals": { "s3:x-amz-acl": [ "public-read" ] } } }, { "Sid": '
+                                 '"AddPerm", "Effect": "Allow", "Principal": "*", "Action": "s3:GetObject", "Resource": '
+                                 '"arn:aws:s3:::my_bucket/*", "Condition": { "Bool": { "aws:SecureTransport": "false" }'
+                                 ' } }, { "Sid": "YetAnotherStatement", "Effect": "Allow", "Principal": "*", "Action": '
+                                 '[ "s3:PutObject", "s3:PutObjectAcl" ], "Resource": [ "arn:aws:s3:::examplebucket/*" '
+                                 '], "Condition": { "StringEquals": { "s3:x-amz-acl": [ "public-read" ] } } } ] }')
 }
 
 S3_VERSIONING_BUCKETS = {

--- a/chalice/tests/chalicelib/criteria/test_data.py
+++ b/chalice/tests/chalicelib/criteria/test_data.py
@@ -2015,12 +2015,6 @@ S3_BUCKET_POLICY_BUCKETS = {
             'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
         }
     ],
-    'fail_only_insecure': [
-        {
-            'Name': 'fail_only_insecure_bucket',
-            'CreationDate': datetime.datetime(2000, 1,  1,  1,  0,  0),
-        }
-    ],
     'pass': [
         {
             'Name': 'pass_bucket',
@@ -2040,10 +2034,6 @@ S3_BUCKET_POLICIES = {
                                  '"s3:GetObject", "Resource": "arn:aws:s3:::my_bucket/*", "Condition": '
                                  '{"StringLike": {"aws:Referer": ["http://www.example.com/*", '
                                  '"http://example.com/*"]}}}]}'),
-    'fail_only_insecure': ('{"Version": "2008-10-17", "Id": "some_policy", "Statement": [{"Sid": '
-                           '"AddPerm", "Effect": "Allow", "Principal": {"AWS": "*"}, "Action": '
-                           '"s3:GetObject", "Resource": "arn:aws:s3:::my_bucket/*", "Condition": '
-                           '{"Bool": {"aws:SecureTransport": "false"}}}]}'),
     'pass': ('{"Version": "2008-10-17", "Id": "some_policy", "Statement": [{"Sid": '
              '"AddPerm", "Effect": "Allow", "Principal": {"AWS": "*"}, "Action": '
              '"s3:GetObject", "Resource": "arn:aws:s3:::my_bucket/*", "Condition": '


### PR DESCRIPTION
This is to fix the criterion as it did too much - it was only supposed to check if the aws:SecureTransport condition existed in a policy, not whether it was set to true or false.

(Background: aws:SecureTransport represents whether a connection to the bucket was made using HTTPS. It is set to true if HTTPS was used, false if not.)

This is because it is possible to have a secure bucket policy by using the condition's false status to *deny* access to the bucket, which I didn't consider. However, the previous version of the evaluate method in the criterion would have failed such a policy.

It may be a good idea to re-work this check again in the future, by having the evaluate method look at the policy in greater detail to make sure that access is being allowed or denied for the correct values of  aws:SecureTransport. Currently, we make the assumption that if the person writing the policy makes the effort to mention SecureTransport, they'll be doing it to make sure access only occurs on HTTPS connections - which may be a bit naive...