### PR TITLE
CT-616 - Label an audit finished even if it is not complete. 

### DIFF
--- a/build/sql/definition/00014.sql
+++ b/build/sql/definition/00014.sql
@@ -1,0 +1,3 @@
+ALTER TABLE audit_criterion ADD COLUMN attempted BOOLEAN DEFAULT FALSE;
+
+ALTER TABLE account_audit ADD COLUMN finished BOOLEAN DEFAULT FALSE;

--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -606,6 +606,7 @@ class AccountAudit(database_handle.BaseModel):
     criteria_passed = peewee.IntegerField(default=0)
     criteria_failed = peewee.IntegerField(default=0)
     issues_found = peewee.IntegerField(default=0)
+    finished = peewee.BooleanField(default=False)
 
     class Meta:
         table_name = "account_audit"
@@ -786,6 +787,7 @@ class AuditCriterion(database_handle.BaseModel):
     failed = peewee.IntegerField(default=0)
     ignored = peewee.IntegerField(default=0)
     processed = peewee.BooleanField(default=False)
+    attempted = peewee.BooleanField(default=False)
 
     class Meta:
         table_name = "audit_criterion"


### PR DESCRIPTION
Each audit_criterion is marked as attempted=True even if it is not successfully processed. 
This means we can then mark an audit as finished when every check has been attempted even if it is not complete (every check has been successfully processed). 
The latest audit is then the most recent "finished" audit rather than the most recent "completed" audit. 