### PR TITLE
CT-632 - Save audit as soon as active criteria count are set.

### DIFF
--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -97,6 +97,7 @@ def account_audit_criteria(event):
             app.log.debug(message.body)
             audit = models.AccountAudit.get_by_id(audit_data['id'])
             audit.active_criteria = len(list(active_criteria))
+            audit.save()
             for criterion in active_criteria:
                 audit_criterion = models.AuditCriterion.create(
                     account_audit_id=audit,


### PR DESCRIPTION
Currently the next step of the audit can start running as soon as the first SQS message is written so it sometimes starts before the active criteria count is set. 