### PR TITLE
CT-633 - Correct is_regional and active settings on checks

### DIFF
--- a/chalice/chalicelib/criteria/aws_iam_validate_inspector_policy.py
+++ b/chalice/chalicelib/criteria/aws_iam_validate_inspector_policy.py
@@ -12,6 +12,8 @@ class AwsIamValidateInspectorPolicy(CriteriaDefault):
 
     active = True
 
+    is_regional = False
+
     ClientClass = GdsIamClient
 
     resource_type = "AWS::IAM::Policy"

--- a/chalice/chalicelib/criteria/aws_vpc_flow_logs_enabled.py
+++ b/chalice/chalicelib/criteria/aws_vpc_flow_logs_enabled.py
@@ -8,7 +8,9 @@ from chalicelib.aws.gds_ec2_security_group_client import GdsEc2SecurityGroupClie
 
 class AwsVpcFlowLogsEnabled(CriteriaDefault):
 
-    active = True
+    # This can be switched on when the client role has been iterated.
+    # At present the permissions are not in the role
+    active = False
 
     is_regional = True
 


### PR DESCRIPTION
IAM Inspector role: is_regional = False
VPC flow log check: active = False - since we don't have the DescribeVpcs permission in the client role