### PR TITLE
[CT-341] Update pip packages

### DIFF
--- a/chalice/requirements-dev.txt
+++ b/chalice/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 chalice==1.8.0
-flake8==3.5.0
+flake8==3.7.7
 safety==1.8.4
 sshtunnel==0.1.4
 argparse==1.4.0

--- a/chalice/requirements-dev.txt
+++ b/chalice/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-chalice==1.6.0
+chalice==1.8.0
 flake8==3.5.0
 safety==1.8.4
 sshtunnel==0.1.4

--- a/chalice/requirements-dev.txt
+++ b/chalice/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 chalice==1.8.0
 flake8==3.7.7
-safety==1.8.4
+safety==1.8.5
 sshtunnel==0.1.4
 argparse==1.4.0
 behave==1.2.6

--- a/chalice/requirements.txt
+++ b/chalice/requirements.txt
@@ -3,7 +3,7 @@ psycopg2-binary==2.8.2
 peewee==3.9.5
 cerberus==1.2
 httplib2==0.12.3
-google-auth==1.5.1
+google-auth==1.6.3
 google-auth-oauthlib==0.2.0
 jinja2==2.10.1
 webassets==0.12.1

--- a/chalice/requirements.txt
+++ b/chalice/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.9.154
 psycopg2-binary==2.8.2
-peewee==3.6.4
+peewee==3.9.5
 cerberus==1.2
 httplib2==0.11.3
 google-auth==1.5.1

--- a/chalice/requirements.txt
+++ b/chalice/requirements.txt
@@ -7,5 +7,5 @@ google-auth==1.6.3
 google-auth-oauthlib==0.2.0
 jinja2==2.10.1
 webassets==0.12.1
-PyJWT==1.6.4
+PyJWT==1.7.1
 netaddr==0.7.19

--- a/chalice/requirements.txt
+++ b/chalice/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.9.154
-psycopg2-binary==2.7.5
+psycopg2-binary==2.8.2
 peewee==3.6.4
 cerberus==1.2
 httplib2==0.11.3

--- a/chalice/requirements.txt
+++ b/chalice/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.9.154
 psycopg2-binary==2.8.2
 peewee==3.9.5
 cerberus==1.2
-httplib2==0.11.3
+httplib2==0.12.3
 google-auth==1.5.1
 google-auth-oauthlib==0.2.0
 jinja2==2.10.1

--- a/chalice/requirements.txt
+++ b/chalice/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.7.59
+boto3==1.9.154
 psycopg2-binary==2.7.5
 peewee==3.6.4
 cerberus==1.2

--- a/chalice/requirements.txt
+++ b/chalice/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.9.154
 psycopg2-binary==2.8.2
 peewee==3.9.5
-cerberus==1.2
+cerberus==1.3.1
 httplib2==0.12.3
 google-auth==1.6.3
 google-auth-oauthlib==0.3.0

--- a/chalice/requirements.txt
+++ b/chalice/requirements.txt
@@ -4,7 +4,7 @@ peewee==3.9.5
 cerberus==1.2
 httplib2==0.12.3
 google-auth==1.6.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.3.0
 jinja2==2.10.1
 webassets==0.12.1
 PyJWT==1.7.1


### PR DESCRIPTION
Not a lot of very significant changes. For each update, I made sure that:
- All unit tests passed
- `gulp environment.redeploy` runs and completes
- A manual account audit completes

There are two things to note here:
- After all of these updates, there are still 4 packages that are marked as outdated: `attrs`, `click`, `pip` and `typing`. These are all due to the most current version of Chalice requiring them to be a certain version, which can be seen here: https://github.com/aws/chalice/blob/master/setup.py
- When running `pip install -r requirements-dev.txt`, there is an "error", with the message `ERROR: botocore 1.12.154 has requirement urllib3<1.25,>=1.20; python_version >= "3.4", but you'll have urllib3 1.25.2 which is incompatible.` This is due to botocore devs not properly updating the requirements in the repo (see https://github.com/boto/botocore/pull/1737). The build still works, however, so there's no reason to be concerned. A future update to boto3 should fix it.