### PR TITLE
CT-735 - Correct unittest which assumed the active state of all checks must be True

### DIFF
--- a/chalice/tests/chalicelib/criteria/test_criteria_default.py
+++ b/chalice/tests/chalicelib/criteria/test_criteria_default.py
@@ -244,7 +244,9 @@ class CriteriaSubclassTestCaseMixin(object):
         test that all instance variables have the expected initial values
         """
         with self.subTest():
-            self.assertTrue(self.subclass.active, msg="active must be True")
+            # Checks do not have to be active but value should be set and boolean
+            #    self.assertTrue(self.subclass.active, msg="active must be True")
+            self.assertIn(self.subclass.active, [True,False], msg="active must be True")
         with self.subTest():
             self.assertNotEqual(
                 self.subclass.resource_type,

--- a/chalice/tests/chalicelib/criteria/test_criteria_default.py
+++ b/chalice/tests/chalicelib/criteria/test_criteria_default.py
@@ -246,7 +246,7 @@ class CriteriaSubclassTestCaseMixin(object):
         with self.subTest():
             # Checks do not have to be active but value should be set and boolean
             #    self.assertTrue(self.subclass.active, msg="active must be True")
-            self.assertIn(self.subclass.active, [True,False], msg="active must be True")
+            self.assertIn(self.subclass.active, [True,False], msg="active must be set and boolean")
         with self.subTest():
             self.assertNotEqual(
                 self.subclass.resource_type,


### PR DESCRIPTION
Changed to check active is set and is boolean.