### PR TITLE
CT-728 - Switch to automated account subscription updates

### DIFF
--- a/build/sql/definition/00100.sql
+++ b/build/sql/definition/00100.sql
@@ -1,0 +1,15 @@
+-- Create a default team to assign new account subscriptions to
+-- These should be monitored and added to a real team.
+INSERT INTO public.product_team (team_name, active)
+VALUES ('TBC', true);
+
+-- Add properties to account subscription table to record
+-- reason for inactive accounts
+ALTER TABLE public.account_subscription
+ADD COLUMN suspended BOOLEAN DEFAULT FALSE;
+
+ALTER TABLE public.account_subscription
+ADD COLUMN auditable BOOLEAN DEFAULT FALSE;
+
+ALTER TABLE public.account_subscription
+ADD CONSTRAINT account_subscription_account_id UNIQUE (account_id);

--- a/chalice/chalicelib/api/derived_stats_tables/00_current_coverage_stats.sql
+++ b/chalice/chalicelib/api/derived_stats_tables/00_current_coverage_stats.sql
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS public._current_coverage_stats;
+
+CREATE TABLE public._current_coverage_stats AS
+SELECT
+  COUNT(*) AS accounts,
+  SUM(CASE WHEN active THEN 1 ELSE 0 END) AS active,
+  SUM(CASE WHEN auditable THEN 1 ELSE 0 END) AS auditable,
+  SUM(CASE WHEN suspended THEN 1 ELSE 0 END) AS suspended,
+  CAST(SUM(CASE WHEN auditable THEN 1 ELSE 0 END) AS FLOAT)/SUM(CASE WHEN active THEN 1 ELSE 0 END) AS coverage
+FROM public.account_subscription;

--- a/chalice/chalicelib/api/derived_stats_tables/00_current_coverage_stats.sql
+++ b/chalice/chalicelib/api/derived_stats_tables/00_current_coverage_stats.sql
@@ -6,5 +6,6 @@ SELECT
   SUM(CASE WHEN active THEN 1 ELSE 0 END) AS active,
   SUM(CASE WHEN auditable THEN 1 ELSE 0 END) AS auditable,
   SUM(CASE WHEN suspended THEN 1 ELSE 0 END) AS suspended,
+  COUNT(*) - SUM(CASE WHEN suspended THEN 1 ELSE 0 END) AS enabled,
   CAST(SUM(CASE WHEN auditable THEN 1 ELSE 0 END) AS FLOAT)/SUM(CASE WHEN active THEN 1 ELSE 0 END) AS coverage
 FROM public.account_subscription;

--- a/chalice/chalicelib/api/derived_stats_tables/02_current_summary_stats.sql
+++ b/chalice/chalicelib/api/derived_stats_tables/02_current_summary_stats.sql
@@ -8,7 +8,7 @@ SELECT
   summary.avg_fails_per_account,
   summary.avg_percent_fails_per_account,
   summary.accounts_audited,
-  CAST(summary.accounts_audited AS FLOAT)/(coverage.accounts - coverage.suspended) AS percent_accounts_audited
+  CAST(summary.accounts_audited AS FLOAT)/(coverage.enabled) AS percent_accounts_audited
 FROM (
   SELECT
     SUM(acc.resources) AS total_resources,

--- a/chalice/chalicelib/api/derived_stats_tables/02_current_summary_stats.sql
+++ b/chalice/chalicelib/api/derived_stats_tables/02_current_summary_stats.sql
@@ -2,13 +2,24 @@
 DROP TABLE IF EXISTS public._current_summary_stats;
 CREATE TABLE public._current_summary_stats AS
 SELECT
-    SUM(resources) AS total_resources,
-    SUM(failed) AS total_failures,
-    AVG(resources) AS avg_resources_per_account,
-    AVG(failed) AS avg_fails_per_account,
-    AVG(ratio) AS avg_percent_fails_per_account,
-    COUNT(account_id) AS accounts_audited,
-    CAST(COUNT(account_id) AS FLOAT)/80 AS percent_accounts_audited
-FROM public._current_account_stats;
+  summary.total_resources,
+  summary.total_failures,
+  summary.avg_resources_per_account,
+  summary.avg_fails_per_account,
+  summary.avg_percent_fails_per_account,
+  summary.accounts_audited,
+  CAST(summary.accounts_audited AS FLOAT)/(coverage.accounts - coverage.suspended) AS percent_accounts_audited
+FROM (
+  SELECT
+    SUM(acc.resources) AS total_resources,
+    SUM(acc.failed) AS total_failures,
+    AVG(acc.resources) AS avg_resources_per_account,
+    AVG(acc.failed) AS avg_fails_per_account,
+    AVG(acc.ratio) AS avg_percent_fails_per_account,
+    COUNT(acc.account_id) AS accounts_audited
+  FROM public._current_account_stats AS acc
+) AS summary
+JOIN public._current_coverage_stats AS coverage
+ON 1 = 1;
 
 

--- a/chalice/chalicelib/api/derived_stats_tables/05_daily_summary_stats.sql
+++ b/chalice/chalicelib/api/derived_stats_tables/05_daily_summary_stats.sql
@@ -9,7 +9,7 @@ SELECT
   summary.avg_fails_per_account,
   summary.avg_percent_fails_per_account,
   summary.accounts_audited,
-  CAST(summary.accounts_audited AS FLOAT)/(coverage.accounts - coverage.suspended) AS percent_accounts_audited
+  CAST(summary.accounts_audited AS FLOAT)/(coverage.enabled) AS percent_accounts_audited
 FROM (
   SELECT
     audit_date,

--- a/chalice/chalicelib/api/derived_stats_tables/05_daily_summary_stats.sql
+++ b/chalice/chalicelib/api/derived_stats_tables/05_daily_summary_stats.sql
@@ -2,17 +2,29 @@
 DROP TABLE IF EXISTS public._daily_summary_stats;
 CREATE TABLE public._daily_summary_stats AS
 SELECT
+  summary.audit_date,
+  summary.total_resources,
+  summary.total_failures,
+  summary.avg_resources_per_account,
+  summary.avg_fails_per_account,
+  summary.avg_percent_fails_per_account,
+  summary.accounts_audited,
+  CAST(summary.accounts_audited AS FLOAT)/(coverage.accounts - coverage.suspended) AS percent_accounts_audited
+FROM (
+  SELECT
     audit_date,
     SUM(resources) AS total_resources,
     SUM(failed) AS total_failures,
     AVG(resources) AS avg_resources_per_account,
     AVG(failed) AS avg_fails_per_account,
     AVG(ratio) AS avg_percent_fails_per_account,
-    COUNT(DISTINCT account_id) AS accounts_audited,
-    CAST(COUNT(DISTINCT account_id) AS FLOAT)/80 AS percent_accounts_audited
-FROM public._daily_account_stats
-GROUP BY audit_date
-ORDER BY audit_date DESC;
+    COUNT(DISTINCT account_id) AS accounts_audited
+  FROM public._daily_account_stats
+  GROUP BY audit_date
+  ORDER BY audit_date DESC
+) AS summary
+JOIN public._current_coverage_stats AS coverage
+ON 1 = 1;
 
 CREATE INDEX daily_summary_stats__audit_date ON public._daily_summary_stats (audit_date);
 

--- a/chalice/chalicelib/api/derived_stats_tables/07_monthly_summary_stats.sql
+++ b/chalice/chalicelib/api/derived_stats_tables/07_monthly_summary_stats.sql
@@ -2,6 +2,17 @@
 DROP TABLE IF EXISTS public._monthly_summary_stats;
 CREATE TABLE public._monthly_summary_stats AS
 SELECT
+  summary.audit_year,
+  summary.audit_month,
+  summary.total_resources,
+  summary.total_failures,
+  summary.avg_resources_per_account,
+  summary.avg_fails_per_account,
+  summary.avg_percent_fails_per_account,
+  summary.accounts_audited,
+  CAST(summary.accounts_audited AS FLOAT)/(coverage.accounts - coverage.suspended) AS percent_accounts_audited
+FROM (
+  SELECT
     CAST(date_part('YEAR', audit_date) AS INTEGER) AS audit_year,
     CAST(date_part('MONTH', audit_date) AS INTEGER) AS audit_month,
     SUM(resources) AS total_resources,
@@ -9,11 +20,13 @@ SELECT
     AVG(resources) AS avg_resources_per_account,
     AVG(failed) AS avg_fails_per_account,
     AVG(ratio) AS avg_percent_fails_per_account,
-    COUNT(DISTINCT account_id) AS accounts_audited,
-    CAST(COUNT(DISTINCT account_id) AS FLOAT)/80 AS percent_accounts_audited
+    COUNT(DISTINCT account_id) AS accounts_audited
 FROM public._daily_account_stats
 GROUP BY  date_part('YEAR', audit_date),date_part('MONTH', audit_date)
-ORDER BY date_part('YEAR', audit_date) DESC,date_part('MONTH', audit_date) DESC;
+ORDER BY date_part('YEAR', audit_date) DESC,date_part('MONTH', audit_date) DESC
+) AS summary
+JOIN public._current_coverage_stats AS coverage
+ON 1 = 1;
 
 CREATE INDEX monthly_summary_stats__audit_year ON public._monthly_summary_stats (audit_year);
 CREATE INDEX monthly_summary_stats__audit_month ON public._monthly_summary_stats (audit_month);

--- a/chalice/chalicelib/api/derived_stats_tables/07_monthly_summary_stats.sql
+++ b/chalice/chalicelib/api/derived_stats_tables/07_monthly_summary_stats.sql
@@ -10,7 +10,7 @@ SELECT
   summary.avg_fails_per_account,
   summary.avg_percent_fails_per_account,
   summary.accounts_audited,
-  CAST(summary.accounts_audited AS FLOAT)/(coverage.accounts - coverage.suspended) AS percent_accounts_audited
+  CAST(summary.accounts_audited AS FLOAT)/(coverage.enabled) AS percent_accounts_audited
 FROM (
   SELECT
     CAST(date_part('YEAR', audit_date) AS INTEGER) AS audit_year,

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -482,21 +482,15 @@ def update_subscriptions():
         "auditable": 0
     }
 
-    app.log.debug("account list: " + json.dumps(accounts))
-
     for account in accounts:
-        app.log.debug("update: " + str(account))
-        app.log.debug("type: " + str(type(account)))
         is_active = not (account['Status'] == 'SUSPENDED')
         try:
-            app.log.debug("find existing sub: " + str(account))
             sub = models.AccountSubscription.get(
                 models.AccountSubscription.account_id == account['Id']
             )
             sub.active = is_active
             sub.save()
         except models.AccountSubscription.DoesNotExist as err:
-            app.log.debug("new sub")
             app.log.debug(app.utilities.get_typed_exception(err))
             account_stats["new"] += 1
             sub = models.AccountSubscription.create(

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -482,6 +482,8 @@ def update_subscriptions():
         "auditable": 0
     }
 
+    app.log.debug("account list: " + json.dumps(accounts))
+
     for account in accounts:
         app.log.debug("update: " + str(account))
         app.log.debug("type: " + str(type(account)))

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -11,6 +11,7 @@ from chalice import Rate
 from app import app
 from chalicelib.aws.gds_sqs_client import GdsSqsClient
 from chalicelib.aws.gds_ec2_client import GdsEc2Client
+from chalicelib.aws.gds_organizations_client import GdsOrganizationsClient
 from chalicelib import models
 from chalicelib.criteria.aws_ec2_security_group_ingress_open import (
     AwsEc2SecurityGroupIngressOpen,
@@ -398,3 +399,20 @@ def audit_evaluated_metric(event):
     except Exception as err:
         app.log.error(str(err))
     return status
+
+
+def update_subscriptions():
+    #client = GdsOrganizationsClient()
+    #session = client.get_chain_assume_session()
+    #accounts = client.list_accounts()
+
+
+
+@app.lambda_function()
+def manual_update_subscriptions(event, context):
+    update_subscriptions()
+
+
+@app.schedule(Rate(24, unit=Rate.HOURS))
+def schedule_update_subscriptions(event, context):
+    update_subscriptions()

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -490,7 +490,7 @@ def update_subscriptions():
             )
             sub.active = is_active
             sub.save()
-        except models.AccountSubscripton.DoesNotExist:
+        except models.AccountSubscription.DoesNotExist:
             account_stats["new"] += 1
             sub = models.AccountSubscription.create(
                 account_id = account.Id,

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -486,15 +486,15 @@ def update_subscriptions():
         is_active = not (account['Status'] == 'SUSPENDED')
         try:
             sub = models.AccountSubscription.get(
-                models.AccountSubscription.account_id == account.Id
+                models.AccountSubscription.account_id == account['Id']
             )
             sub.active = is_active
             sub.save()
         except models.AccountSubscription.DoesNotExist:
             account_stats["new"] += 1
             sub = models.AccountSubscription.create(
-                account_id = account.Id,
-                account_name = account.Name,
+                account_id = account['Id'],
+                account_name = account['Name'],
                 product_team_id = default_team,
                 active = is_active
             )

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -423,7 +423,7 @@ def get_default_audit_account_list():
         params = ssm.get_parameters_by_path('/csw/audit_defaults', True)
 
         for item in params:
-            account = json.loads(item['Value'])
+            account = ssm.parse_escaped_json_parameter(item['Value'])
             app.log.debug(str(account))
             accounts.append(account)
     except Exception as err:

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -484,7 +484,7 @@ def update_subscriptions():
 
     for account in accounts:
         app.log.debug("update: " + str(account))
-        app.log.debug("type: " + type(account))
+        app.log.debug("type: " + str(type(account)))
         is_active = not (account['Status'] == 'SUSPENDED')
         try:
             sub = models.AccountSubscription.get(

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -489,7 +489,7 @@ def update_subscriptions():
         app.log.debug("type: " + str(type(account)))
         is_active = not (account['Status'] == 'SUSPENDED')
         try:
-            app.log.debug("find existing sub: " + str(account['Id']))
+            app.log.debug("find existing sub: " + str(account))
             sub = models.AccountSubscription.get(
                 models.AccountSubscription.account_id == account['Id']
             )

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -424,7 +424,7 @@ def get_default_audit_account_list():
 
         for item in params:
             account = ssm.parse_escaped_json_parameter(item['Value'])
-            app.log.debug(str(account))
+            app.log.debug("list: " + str(account))
             accounts.append(account)
     except Exception as err:
         app.log.debug(app.utilities.get_typed_exception(err))
@@ -483,7 +483,8 @@ def update_subscriptions():
     }
 
     for account in accounts:
-        app.log.debug(str(account))
+        app.log.debug("update: " + str(account))
+        app.log.debug("type: " + type(account))
         is_active = not (account['Status'] == 'SUSPENDED')
         try:
             sub = models.AccountSubscription.get(

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -423,7 +423,9 @@ def get_default_audit_account_list():
         params = ssm.get_parameters_by_path('/csw/audit_defaults', True)
 
         for item in params:
-            accounts.append(json.loads(item['Value'].decode('utf-8')))
+            account = json.loads(item['Value'])
+            app.log.debug(str(account))
+            accounts.append(account)
     except Exception as err:
         app.log.debug(app.utilities.get_typed_exception(err))
 

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -483,6 +483,7 @@ def update_subscriptions():
     }
 
     for account in accounts:
+        app.log.debug(str(account))
         is_active = not (account['Status'] == 'SUSPENDED')
         try:
             sub = models.AccountSubscription.get(

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -487,7 +487,7 @@ def update_subscriptions():
         app.log.debug("type: " + str(type(account)))
         is_active = not (account['Status'] == 'SUSPENDED')
         try:
-            app.log.debug("find existing sub")
+            app.log.debug("find existing sub: " + str(account['Id']))
             sub = models.AccountSubscription.get(
                 models.AccountSubscription.account_id == account['Id']
             )

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -529,7 +529,7 @@ def manual_update_subscriptions(event, context):
     via a call to aws lambda invoke
     """
     stats = update_subscriptions()
-    return json.dumps(stats)
+    return stats
 
 
 if os.environ['CSW_ENV'] == 'prod':

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -492,7 +492,9 @@ def update_subscriptions():
             )
             sub.active = is_active
             sub.save()
-        except models.AccountSubscription.DoesNotExist:
+        except models.AccountSubscription.DoesNotExist as err:
+            app.log.debug("new sub")
+            app.log.debug(app.utilities.get_typed_exception(err))
             account_stats["new"] += 1
             sub = models.AccountSubscription.create(
                 account_id = account['Id'],

--- a/chalice/chalicelib/aws/gds_organizations_client.py
+++ b/chalice/chalicelib/aws/gds_organizations_client.py
@@ -1,0 +1,32 @@
+"""
+GdsOrganizationsClient
+extends GdsAwsClient
+implements aws Key Management Service endpoint queries
+"""
+from chalicelib.aws.gds_aws_client import GdsAwsClient
+
+
+class GdsOrganizationsClient(GdsAwsClient):
+    """
+    The organizations client gives us access to list accounts linked
+    to the parent organization account
+    """
+    def get_accounts(self, session):
+        """Get a list of AWS organization linked accounts.
+        :param session: The boto3 session to use for the connection
+        :returns: A list of accounts
+        :rtype: list
+        """
+        client = self.get_boto3_session_client('organizations', session)
+
+        results = client.list_accounts(MaxResults=20)
+        accounts = results['Accounts']
+
+        while 'NextToken' in results:
+            results = client.list_accounts(
+                MaxResults=20,
+                NextToken=results['NextToken']
+            )
+            accounts += results['Accounts']
+
+        return accounts

--- a/chalice/chalicelib/aws/gds_organizations_client.py
+++ b/chalice/chalicelib/aws/gds_organizations_client.py
@@ -11,7 +11,7 @@ class GdsOrganizationsClient(GdsAwsClient):
     The organizations client gives us access to list accounts linked
     to the parent organization account
     """
-    def get_accounts(self, session):
+    def list_accounts(self, session):
         """Get a list of AWS organization linked accounts.
         :param session: The boto3 session to use for the connection
         :returns: A list of accounts

--- a/chalice/chalicelib/aws/gds_ssm_client.py
+++ b/chalice/chalicelib/aws/gds_ssm_client.py
@@ -27,6 +27,19 @@ class GdsSsmClient(GdsAwsClient):
 
         return params
 
+    def get_parameters_by_path(self, path, decrypt, recursive=True):
+
+        ssm = self.get_default_client("ssm")
+
+        response = ssm.get_parameters_by_path(
+            Path=path,
+            Recursive=recursive,
+            WithDecryption=decrypt
+        )
+        params = response["Parameters"]
+
+        return params
+
     def parse_escaped_json_parameter(self, value):
         parsed = json.loads(value.replace("\\", ""))
         return parsed

--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -548,6 +548,8 @@ class AccountSubscription(database_handle.BaseModel):
         ProductTeam, backref="account_subscriptions"
     )
     active = peewee.BooleanField()
+    auditable = peewee.BooleanField()
+    suspended = peewee.BooleanField()
 
     class Meta:
         table_name = "account_subscription"

--- a/chalice/chalicelib/utilities.py
+++ b/chalice/chalicelib/utilities.py
@@ -1,5 +1,6 @@
 import os
 import json
+import traceback
 import importlib
 from datetime import datetime, date
 
@@ -63,12 +64,13 @@ class Utilities:
         return ClientClass
 
     def get_typed_exception(self, err):
-        if type(err).__module__ in ["__main__", "builtins"]:
-            error_message = "{}: {}".format(type(err).__name__, err)
-        else:
-            error_message = "{}.{}: {}".format(
-                type(err).__module__, type(err).__name__, err
-            )
+        #if type(err).__module__ in ["__main__", "builtins"]:
+        #    error_message = "{}: {}".format(type(err).__name__, err)
+        #else:
+        #    error_message = "{}.{}: {}".format(
+        #        type(err).__module__, type(err).__name__, err
+        #    )
+        error_message = traceback.format_exc()
         return error_message
 
     def list_files_from_path(self, path, ext=None):


### PR DESCRIPTION
Subscriptions are updated by running organization list-accounts against the parent account and set to annotated with auditable, suspended properties so we can differentiate between closed accounts and live accounts we can't audit. 