### PR TITLE
CT-726c - Remove blank line in statement due to bug in script parser

### DIFF
--- a/chalice/chalicelib/api/derived_stats_tables/11_resources.sql
+++ b/chalice/chalicelib/api/derived_stats_tables/11_resources.sql
@@ -1,7 +1,6 @@
 DROP TABLE IF EXISTS _resources;
 
 CREATE TABLE _resources AS
-
 SELECT
 res.id AS audit_resource_id,
 res.account_audit_id,


### PR DESCRIPTION
Currently there's a bug in the script parser which treats a blank line in a SQL statement as 2 separate queries. 