### PR TITLE
Add bastion and dev box to known hosts.

### DIFF
--- a/build/gulp_tasks/4.environment.terraform.js
+++ b/build/gulp_tasks/4.environment.terraform.js
@@ -364,7 +364,24 @@ gulp.task("environment.terraform_ssh", function() {
         var hostname = "dev." + domain;
         var prompt = hostname.replace(/\./g, "-");
         var task =
-          "scp build/gulp_helpers/devbox_bootstrap.sh " + hostname + ":~ubuntu";
+          "ssh-keyscan -H " +
+          hostname +
+          " >> " +
+          config.paths.home +
+          "/.ssh/known_hosts";
+        return helpers.runTaskInPipelinePromise(task, config.paths.root, file);
+      })
+    )
+    .pipe(
+      data(function(file) {
+        var domain = file.data.tool + "." + env;
+        var hostname = "dev." + domain;
+        var prompt = hostname.replace(/\./g, "-");
+        var task =
+          "scp " +
+          "build/gulp_helpers/devbox_bootstrap.sh " +
+          hostname +
+          ":~ubuntu";
         return helpers.runTaskInPipelinePromise(task, config.paths.root, file);
       })
     )


### PR DESCRIPTION
This is so we can remove the expect script as part of the concourse
pipeline. This was swallowing errors.