### PR TITLE
Change tracebacks output from multiline-text to JSON.

### DIFF
--- a/chalice/chalicelib/utilities.py
+++ b/chalice/chalicelib/utilities.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import json
 import traceback
@@ -63,15 +64,25 @@ class Utilities:
 
         return ClientClass
 
-    def get_typed_exception(self, err):
-        # if type(err).__module__ in ["__main__", "builtins"]:
-        #    error_message = "{}: {}".format(type(err).__name__, err)
-        # else:
-        #    error_message = "{}.{}: {}".format(
-        #        type(err).__module__, type(err).__name__, err
-        #    )
-        error_message = traceback.format_exc()
-        return error_message
+    def get_typed_exception(self):
+        """Finds the current exception and returns a JSON formatted
+        representation. Useful when outputting stack traces to
+        cloudwatch.
+
+        """
+        return json.dumps(
+            [
+                {
+                    "filename": frame.filename,
+                    "line": frame.line,
+                    "lineno": frame.lineno,
+                    "locals": frame.locals,
+                    "name": frame.name,
+                }
+                for frame in traceback.extract_tb(sys.exc_info()[2])
+            ]
+        )
+
 
     def list_files_from_path(self, path, ext=None):
         """

--- a/chalice/requirements-dev.txt
+++ b/chalice/requirements-dev.txt
@@ -6,3 +6,4 @@ sshtunnel==0.1.4
 argparse==1.4.0
 behave==1.2.6
 selenium==3.141.0
+coverage==4.5.3

--- a/chalice/tests/chalicelib/test_utilities.py
+++ b/chalice/tests/chalicelib/test_utilities.py
@@ -1,0 +1,55 @@
+import unittest
+import json
+from chalicelib.utilities import Utilities
+
+
+class TestUtilities_to_json(unittest.TestCase):
+    """
+    Unit tests for the `utilities.to_json` method
+    """
+
+    def setUp(self):
+        self.u = Utilities()
+        self.obj = {}
+        self.json = self.u.to_json(self.obj)
+        self.loaded_obj = json.loads(self.json)
+
+    def test_to_json_returns_json(self):
+        """ Test `to_json` converts an object to valid JSON.
+        """
+        self.assertEqual(self.obj, self.loaded_obj)
+
+
+class TestUtilities_get_typed_exception(unittest.TestCase):
+    """
+    Unit tests for the `utilities.get_typed_exception` method
+    """
+
+    def setUp(self):
+        self.u = Utilities()
+        try:
+            raise ValueError
+        except ValueError:
+            self.tb = self.u.get_typed_exception()
+        self.fragments = [
+            "/tests/chalicelib/test_utilities.py",
+            "line",
+            "setUp",
+            "ValueError",
+        ]
+
+    def test_get_typed_excpetion_contains_an_exception(self):
+        """ Check get_typed_exception returns a formated exception.
+
+        The Exception looks like
+        File "/home/user/csw-backend/chalice/tests/chalicelib/test_utilities.py", line 30, in setUp
+           raise ValueError
+        ValueError
+        """
+        for s in self.fragments:
+            with self.subTest(s=s):
+                self.assertIn(s, self.tb)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Tracebacks outputted using the default formatter are multiline
events. This makes it difficult to reconstruct using Cloudwatch
insights as logs from multiple lambdas are interleaved. Changing
output format to JSON makes it easier to search for, and debug
exceptions.