### PR TITLE
Make exception handling consistent.

### DIFF
--- a/chalice/chalicelib/api.py
+++ b/chalice/chalicelib/api.py
@@ -45,8 +45,11 @@ def read_script(script_path):
             # then the last command gets missed if you don't do this
             if len(command) > 0:
                 commands.append(command)
-    except Exception as err:
-        print(f"Failed to open script: {script_path}: " + str(err))
+    except Exception:
+        app.log.error(
+            f"Failed to open script: {script_path}:"
+            + app.utilities.get_typed_exception()
+        )
 
     return commands
 
@@ -72,9 +75,9 @@ def execute_update_usage_stats_tables(event, context):
             app.log.debug(json.dumps(commands))
             dbh.execute_commands(commands, "csw")
         status = 1
-    except Exception as err:
+    except Exception:
         app.log.error(
-            "Update stats tables error: " + app.utilities.get_typed_exception(err)
+            "Update stats tables error: " + app.utilities.get_typed_exception()
         )
     return {"status": status, "commands": commands}
 
@@ -375,8 +378,8 @@ def route_api_prometheus_metrics():
             metric_data += f"# TYPE {metric['name']} {metric['metric_type']}\n"
             metric_data += f"{metric['name']} {metric['data']}\n"
 
-    except Exception as err:
-        app.log.error(app.utilities.get_typed_exception(err))
+    except Exception:
+        app.log.error(app.utilities.get_typed_exception())
         status_code = 500
 
     response = {

--- a/chalice/chalicelib/audit.py
+++ b/chalice/chalicelib/audit.py
@@ -118,12 +118,12 @@ def account_audit_criteria(event):
                     message_body = app.utilities.to_json(audit_criterion.serialize())
                     message_id = sqs.send_message(queue_url, message_body)
                     messages.append(message_id)
-                except KeyError as err:
-                    app.log.error(app.utilities.get_typed_exception(err))
+                except KeyError:
+                    app.log.error(app.utilities.get_typed_exception())
             audit.date_updated = datetime.now()
             audit.save()
-    except Exception as err:
-        app.log.error(str(err))
+    except Exception:
+        app.log.error(app.utilities.get_typed_exception())
     return status
 
 
@@ -297,9 +297,8 @@ def account_evaluate_criteria(event):
                 queue_url, message_body
             )  # TODO: unecessary assignment?
 
-    except Exception as err:
-        # app.log.error(str(err))
-        app.log.error(app.utilities.get_typed_exception(err))
+    except Exception:
+        app.log.error(app.utilities.get_typed_exception())
     return status
 
 
@@ -426,8 +425,8 @@ def get_default_audit_account_list():
             account = ssm.parse_escaped_json_parameter(item["Value"])
             app.log.debug("list: " + str(account))
             accounts.append(account)
-    except Exception as err:
-        app.log.debug(app.utilities.get_typed_exception(err))
+    except Exception:
+        app.log.error(app.utilities.get_typed_exception())
 
     return accounts
 
@@ -486,8 +485,8 @@ def update_subscriptions():
             )
             sub.active = is_active
             sub.save()
-        except models.AccountSubscription.DoesNotExist as err:
-            app.log.debug(app.utilities.get_typed_exception(err))
+        except models.AccountSubscription.DoesNotExist:
+            app.log.error(app.utilities.get_typed_exception())
             account_stats["new"] += 1
             sub = models.AccountSubscription.create(
                 account_id=account["Id"],
@@ -501,9 +500,9 @@ def update_subscriptions():
             account_stats["live"] += 1
             try:
                 assume_role = default_client.assume_chained_role(sub.account_id)
-            except Exception as err:
+            except Exception:
                 assume_role = False
-                app.log.debug(app.utilities.get_typed_exception(err))
+                app.log.error(app.utilities.get_typed_exception())
             if assume_role:
                 account_stats["auditable"] += 1
                 sub.auditable = True

--- a/chalice/chalicelib/aws/gds_aws_client.py
+++ b/chalice/chalicelib/aws/gds_aws_client.py
@@ -299,8 +299,8 @@ class GdsAwsClient:
                 assumed = self.assume_role(
                     target_account, chain["target_role"], session=chain_session
                 )
-        except Exception as err:
-            self.app.log.error(self.app.utilities.get_typed_exception(err))
+        except Exception:
+            self.app.log.error(self.app.utilities.get_typed_exception())
 
         return assumed
 
@@ -320,7 +320,7 @@ class GdsAwsClient:
                 target_session = self.get_session(
                     target_account, chain["target_role"], session=chain_session
                 )
-        except Exception as err:
-            self.app.log.error(self.app.utilities.get_typed_exception(err))
+        except Exception:
+            self.app.log.error(self.app.utilities.get_typed_exception())
 
         return target_session

--- a/chalice/chalicelib/aws/gds_s3_client.py
+++ b/chalice/chalicelib/aws/gds_s3_client.py
@@ -25,7 +25,8 @@ class GdsS3Client(GdsAwsClient):
                 "Policy"
             ]  # This is actually a JSON string instead of a dict. Don't ask me why
         except Exception as exception:
-            policy = str(exception)
+            self.app.log.error(self.app.utilities.get_typed_exception())
+            policy = "{}"
 
         return policy
 
@@ -41,8 +42,8 @@ class GdsS3Client(GdsAwsClient):
             # Don't try to get versioning without a name
             if bucket_name is not None and bucket_name != "":
                 versioning = s3.get_bucket_versioning(Bucket=bucket_name)
-        except Exception as err:
-            self.app.log.debug(self.app.utilities.get_typed_exception(err))
+        except Exception:
+            self.app.log.error(self.app.utilities.get_typed_exception())
 
         return versioning
 
@@ -53,7 +54,7 @@ class GdsS3Client(GdsAwsClient):
         try:
             self.app.log.debug(f"Getting encryption data for {bucket_name}")
             encryption = s3.get_bucket_encryption(Bucket=bucket_name)
-        except Exception as err:
-            self.app.log.debug(f"Error: {err}")
+        except Exception:
+            self.app.log.error(self.app.utilities.get_typed_exception())
 
         return encryption

--- a/chalice/chalicelib/controllers.py
+++ b/chalice/chalicelib/controllers.py
@@ -104,8 +104,8 @@ class FormController:
                     "message": f"Form requested action ({mode}) not recognised",
                 }
 
-        except Exception as err:
-            message = app.utilities.get_typed_exception(err)
+        except Exception:
+            message = app.utilities.get_typed_exception()
             self.processed_status = {
                 "success": False,
                 "message": f"Form {mode} failed: {message}",
@@ -250,9 +250,9 @@ class FormControllerAddResourceException(FormController):
             document["expiry_date"] = expiry_date
 
             app.log.debug(json.dumps(document))
-        except Exception as err:
+        except Exception:
             app.log.error(
-                "Failed to parse post data" + app.utilities.get_typed_exception(err)
+                "Failed to parse post data" + app.utilities.get_typed_exception()
             )
         return document
 
@@ -348,9 +348,9 @@ class FormControllerAddAllowListException(FormController):
             document["expiry_date"] = expiry_date
 
             app.log.debug(json.dumps(document))
-        except Exception as err:
+        except Exception:
             app.log.error(
-                "Failed to parse post data: " + app.utilities.get_typed_exception(err)
+                "Failed to parse post data: " + app.utilities.get_typed_exception()
             )
         return document
 

--- a/chalice/chalicelib/criteria/aws_cloudtrail_log_validation.py
+++ b/chalice/chalicelib/criteria/aws_cloudtrail_log_validation.py
@@ -33,8 +33,8 @@ class CloudTrailFileValidation(CriteriaDefault):
     def get_data(self, session, **kwargs):
         try:
             return self.client.describe_trails(session)
-        except Exception as e:
-            self.app.log.error(self.app.utilities.get_typed_exception(e))
+        except Exception:
+            self.app.log.error(self.app.utilities.get_typed_exception())
             return []
 
     def translate(self, data={}):

--- a/chalice/chalicelib/criteria/aws_cloudtrail_multiregional.py
+++ b/chalice/chalicelib/criteria/aws_cloudtrail_multiregional.py
@@ -30,8 +30,8 @@ class MultiregionalCloudtrail(CriteriaDefault):
     def get_data(self, session, **kwargs):
         try:
             return self.client.describe_trails(session)
-        except Exception as e:
-            self.app.log.error(self.app.utilities.get_typed_exception(e))
+        except Exception:
+            self.app.log.error(self.app.utilities.get_typed_exception())
             return []
 
     def translate(self, data={}):

--- a/chalice/chalicelib/criteria/aws_ebs_encryption.py
+++ b/chalice/chalicelib/criteria/aws_ebs_encryption.py
@@ -56,8 +56,8 @@ class EbsEncryption(CriteriaDefault):
             for vol in self.client.describe_volumes(session):
                 if vol["AvailabilityZone"].startswith(kwargs["region"]):
                     home_volumes.append(vol)
-        except Exception as e:
-            self.app.log.error(self.app.utilities.get_typed_exception(e))
+        except Exception:
+            self.app.log.error(self.app.utilities.get_typed_exception())
         return home_volumes
 
     def translate(self, data={}):

--- a/chalice/chalicelib/criteria/aws_kms_managed_cmk_rotation.py
+++ b/chalice/chalicelib/criteria/aws_kms_managed_cmk_rotation.py
@@ -62,8 +62,8 @@ class ManagedCmkRotation(CriteriaDefault):
     def get_data(self, session, **kwargs):
         try:
             return self.client.get_key_list_with_details(session)
-        except Exception as e:
-            self.app.log.error(self.app.utilities.get_typed_exception(e))
+        except Exception:
+            self.app.log.error(self.app.utilities.get_typed_exception())
             return []
 
     def translate(self, data={}):

--- a/chalice/chalicelib/criteria/aws_rds_encryption.py
+++ b/chalice/chalicelib/criteria/aws_rds_encryption.py
@@ -40,8 +40,8 @@ class RdsEncryption(CriteriaDefault):
             for db in self.client.describe_db_instances(session):
                 if db["AvailabilityZone"].startswith(kwargs["region"]):
                     home_db_instances.append(db)
-        except Exception as e:
-            self.app.log.error(self.app.utilities.get_typed_exception(e))
+        except Exception:
+            self.app.log.error(self.app.utilities.get_typed_exception())
         return home_db_instances
 
     def translate(self, data={}):

--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -1006,10 +1006,8 @@ class ResourceException(database_handle.BaseModel):
                 "Found exception: " + app.utilities.to_json(exception.serialize())
             )
 
-        except Exception as err:
-            app.log.debug(
-                "Exception not found: " + app.utilities.get_typed_exception(err)
-            )
+        except Exception:
+            app.log.error(app.utilities.get_typed_exception())
             exception = None
 
         return exception
@@ -1038,8 +1036,8 @@ class ResourceException(database_handle.BaseModel):
                 exception["expiry_month"] = expiry.month
                 exception["expiry_year"] = expiry.year
 
-        except Exception as err:
-            app.log.debug(app.utilities.get_typed_exception(err))
+        except Exception:
+            app.log.error(app.utilities.get_typed_exception())
             now = datetime.datetime.now()
             expiry = now + datetime.timedelta(days=90)
             exception = {
@@ -1255,8 +1253,8 @@ class HealthMetrics(database_handle.BaseModel):
                     .on_conflict(conflict_target=[cls.name], preserve=[cls.data])
                     .execute()
                 )
-        except Exception as err:
-            app.log.error(app.utilities.get_typed_exception(err))
+        except Exception:
+            app.log.error(app.utilities.get_typed_exception())
 
     @classmethod
     def load_metric_query(cls, metric_name):
@@ -1268,8 +1266,8 @@ class HealthMetrics(database_handle.BaseModel):
             print(abs_path)
             with open(abs_path, "r") as script:
                 query = script.read()
-        except Exception as err:
-            app.log.error(app.utilities.get_typed_exception(err))
+        except Exception:
+            app.log.error(app.utilities.get_typed_exception())
 
         return query
 

--- a/chalice/chalicelib/routes.py
+++ b/chalice/chalicelib/routes.py
@@ -760,9 +760,9 @@ def resource_post_exception(id):
                 "denied.html", app.current_request
             )
 
-    except Exception as err:
+    except Exception:
         app.log.error(
-            "Route: resource exception error: " + app.utilities.get_typed_exception(err)
+            "Route: resource exception error: " + app.utilities.get_typed_exception()
         )
         response = app.templates.default_server_error()
     return Response(**response)

--- a/chalice/chalicelib/utilities.py
+++ b/chalice/chalicelib/utilities.py
@@ -83,7 +83,6 @@ class Utilities:
             ]
         )
 
-
     def list_files_from_path(self, path, ext=None):
         """
         Get a list of items in the directory represented by the relative path `path`, only returning files that end


### PR DESCRIPTION
For Exceptions using the `.get_typed_exception()` helper. The method
signature has been updated to not pass the `err` through to the
function as that is found by searching the current stack. I've also
changed the logging level to be `error` consistently.