### PR TITLE
Update OAuth scopes with "openid"

### DIFF
--- a/chalice/chalicelib/auth.py
+++ b/chalice/chalicelib/auth.py
@@ -39,6 +39,7 @@ class AuthHandler:
         self.token_algorithm = "HS256"
 
         self.scopes = [
+            "openid",
             "https://www.googleapis.com/auth/userinfo.profile",
             "https://www.googleapis.com/auth/userinfo.email",
         ]

--- a/chalice/tests/chalicelib/test_auth.py
+++ b/chalice/tests/chalicelib/test_auth.py
@@ -71,7 +71,7 @@ class TestAuthHandler(unittest.TestCase):
 
         self.assertIsInstance(self.auth.email_domain, str)
 
-        self.assertEqual(len(self.auth.scopes), 2)
+        self.assertEqual(len(self.auth.scopes), 3)
 
         self.assertIsNone(self.auth.cookie)
 
@@ -165,6 +165,16 @@ class TestAuthHandler(unittest.TestCase):
         """
         login_data = self.auth.get_login_data()
         self.assertDictEqual(login_data, self.default_login_data)
+
+    def test_oauth_scopes(self):
+        """Test that OAuth has the correct scopes. Sometimes, Google will
+        update these and break login."""
+        scopes = [
+            "openid",
+            "https://www.googleapis.com/auth/userinfo.profile",
+            "https://www.googleapis.com/auth/userinfo.email",
+        ]
+        assert self.auth.scopes == scopes
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
auth.py:414  self.google_token = flow.fetch_token(code=code)

Logging in with OAuth was breaking on the above code due to the Google
OAuth scopes having been updated. The following error was being
generated but swallowed by the exception handling.

Scope has changed from "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email" to "openid https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email".