### PR TITLE
CT-803 - Fix IAM role filtering - failing on tags.get with no default return value.

### DIFF
--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -621,7 +621,7 @@ class ProductTeam(database_handle.BaseModel):
                 tags = iam_client.tag_list_to_dict(tag_list)
                 app.log.debug(str(tags))
                 # filter by tags
-                is_team_role = tags.get("purpose").lower() == "csw-team-role"
+                is_team_role = tags.get("purpose", "undefined").lower() == "csw-team-role"
                 if is_team_role:
                     role["Tags"] = tag_list
                     role["TagLookup"] = tags


### PR DESCRIPTION
Add default return string to tags.get to ensure lower method is available on the result.