### PR TITLE
CSW-50 - Update derived stats tables to reference only sev 1 failures

### DIFF
--- a/chalice/chalicelib/api/derived_stats_tables/01_current_account_stats.sql
+++ b/chalice/chalicelib/api/derived_stats_tables/01_current_account_stats.sql
@@ -18,7 +18,7 @@ LEFT JOIN public.audit_criterion AS achk
 ON aud.id = achk.account_audit_id
 LEFT JOIN public.criterion AS chk
 ON achk.criterion_id = chk.id
-GROUP BY DATE(aud.date_completed),sub.account_id,aud.id
+GROUP BY DATE(aud.date_completed),sub.account_id,aud.id,chk.severity
 HAVING DATE(aud.date_completed) IS NOT NULL
 AND SUM(achk.resources) > 0
 AND chk.severity = 1;

--- a/chalice/chalicelib/api/derived_stats_tables/01_current_account_stats.sql
+++ b/chalice/chalicelib/api/derived_stats_tables/01_current_account_stats.sql
@@ -16,8 +16,12 @@ INNER JOIN public.account_audit AS aud
 ON lat.account_audit_id = aud.id
 LEFT JOIN public.audit_criterion AS achk
 ON aud.id = achk.account_audit_id
+LEFT JOIN public.criterion AS chk
+ON achk.criterion_id = chk.id
 GROUP BY DATE(aud.date_completed),sub.account_id,aud.id
-HAVING DATE(aud.date_completed) IS NOT NULL AND SUM(achk.resources) > 0;
+HAVING DATE(aud.date_completed) IS NOT NULL
+AND SUM(achk.resources) > 0
+AND chk.severity = 1;
 
 CREATE INDEX current_account_stats__audit_date_index ON public._current_account_stats (audit_date);
 CREATE INDEX current_account_stats__account_id_index ON public._current_account_stats (account_id);

--- a/chalice/chalicelib/api/derived_stats_tables/04_daily_account_stats.sql
+++ b/chalice/chalicelib/api/derived_stats_tables/04_daily_account_stats.sql
@@ -14,8 +14,12 @@ INNER JOIN public.account_subscription AS sub
 ON sub.id = aud.account_subscription_id
 LEFT JOIN public.audit_criterion AS achk
 ON aud.id = achk.account_audit_id
+LEFT JOIN public.criterion AS chk
+ON achk.criterion_id = chk.id
 GROUP BY DATE(aud.audit_date),sub.account_id,aud.id
-HAVING aud.audit_date IS NOT NULL AND SUM(achk.resources) > 0
+HAVING aud.audit_date IS NOT NULL
+AND SUM(achk.resources) > 0
+AND chk.severity = 1
 ORDER BY sub.account_id, DATE(aud.audit_date) DESC;
 
 CREATE INDEX daily_account_stats__account_id ON public._daily_account_stats (account_id);

--- a/chalice/chalicelib/api/derived_stats_tables/06.5_daily_resource_count.sql
+++ b/chalice/chalicelib/api/derived_stats_tables/06.5_daily_resource_count.sql
@@ -12,6 +12,9 @@ INNER JOIN public.audit_resource AS r
 ON rc.audit_resource_id = r.id
 INNER JOIN public.account_audit AS a
 ON r.account_audit_id = a.id
+INNER JOIN public.criterion AS c
+ON r.criterion_id = c.id
 WHERE a.date_completed IS NOT NULL
+AND c.severity = 1
 GROUP BY DATE(a.date_completed)
 ORDER BY DATE(a.date_completed);

--- a/chalice/chalicelib/api/derived_stats_tables/11_resources.sql
+++ b/chalice/chalicelib/api/derived_stats_tables/11_resources.sql
@@ -9,9 +9,12 @@ ids.id
 FROM public.audit_resource AS res
 INNER JOIN public._resource_persistent_ids AS ids
 ON res.resource_persistent_id = ids.resource_persistent_id
+INNER JOIN public.criterion AS c
+ON res.criterion_id = c.id
 INNER JOIN public.account_audit as aud
 ON aud.id = res.account_audit_id
 WHERE res.resource_persistent_id IS NOT NULL
+AND c.severity = 1
 AND age(NOW(), aud.date_started) < INTERVAL '28 days';
 
 CREATE INDEX resources__audit_resource_id ON public._resources (audit_resource_id);

--- a/chalice/chalicelib/templates/components/charts/stats_current_account_percent_failure.html
+++ b/chalice/chalicelib/templates/components/charts/stats_current_account_percent_failure.html
@@ -6,6 +6,7 @@
      above="true"
      ismultiple="false"
      rotated="true"
+     height="{{ ((accounts|length) * 20)  + 100 }}"
 >
     <table class="govuk-table">
         <caption class="govuk-table__caption">Account summary</caption>


### PR DESCRIPTION
We need this change to measure the value we've added through hiding the non-sev-1 errors from the interface. 