### PR TITLE
CSW-53&67 - Improve text for S3 ACL and RDS classic security group checks

### DIFF
--- a/chalice/chalicelib/aws/gds_ec2_security_group_client.py
+++ b/chalice/chalicelib/aws/gds_ec2_security_group_client.py
@@ -23,6 +23,23 @@ class GdsEc2SecurityGroupClient(GdsEc2Client):
 
         return security_groups
 
+    def get_security_group_by_id(self, session, region, id):
+        try:
+            ec2 = self.get_boto3_session_client("ec2", session, region)
+
+            # run describe security groups api call
+            response = ec2.describe_security_groups(
+                GroupIds = [id]
+            )
+
+            group = None
+            if len(response["SecurityGroups"] == 1):
+                group = response["SecurityGroups"][0]
+        except Exception as err:
+            group = None
+
+        return group
+
     def translate(self, data):
 
         item = {"resource_id": data["GroupId"], "resource_name": data["GroupName"]}

--- a/chalice/chalicelib/aws/gds_ec2_security_group_client.py
+++ b/chalice/chalicelib/aws/gds_ec2_security_group_client.py
@@ -25,17 +25,21 @@ class GdsEc2SecurityGroupClient(GdsEc2Client):
 
     def get_security_group_by_id(self, session, region, id):
         try:
-            ec2 = self.get_boto3_session_client("ec2", session, region)
+            if id:
+                ec2 = self.get_boto3_session_client("ec2", session, region)
 
-            # run describe security groups api call
-            response = ec2.describe_security_groups(
-                GroupIds = [id]
-            )
+                # run describe security groups api call
+                response = ec2.describe_security_groups(
+                    GroupIds = [id]
+                )
 
-            group = None
-            if len(response["SecurityGroups"] == 1):
-                group = response["SecurityGroups"][0]
-        except Exception as err:
+                group = None
+                if len(response["SecurityGroups"] == 1):
+                    group = response["SecurityGroups"][0]
+            else:
+                raise Exception("No security group ID provided")
+        except Exception:
+            self.app.log.error(self.app.utilities.get_typed_exception())
             group = None
 
         return group

--- a/chalice/chalicelib/aws/gds_s3_client.py
+++ b/chalice/chalicelib/aws/gds_s3_client.py
@@ -21,11 +21,11 @@ class GdsS3Client(GdsAwsClient):
         try:
             s3 = self.get_boto3_session_client("s3", session)
             response = s3.get_bucket_policy(Bucket=bucket_name)
-            policy = response[
-                "Policy"
-            ]  # This is actually a JSON string instead of a dict. Don't ask me why
+            # This is actually a JSON string instead of a dict. Don't ask me why
+            policy = response["Policy"]
         except Exception as exception:
-            self.app.log.error(self.app.utilities.get_typed_exception())
+            # This is a debug log since buckets don't have to have policies
+            self.app.log.debug(self.app.utilities.get_typed_exception())
             policy = "{}"
 
         return policy
@@ -40,10 +40,10 @@ class GdsS3Client(GdsAwsClient):
         try:
             self.app.log.debug(f"Get bucket versioning for ({bucket_name})")
             # Don't try to get versioning without a name
-            if bucket_name is not None and bucket_name != "":
+            if bucket_name:
                 versioning = s3.get_bucket_versioning(Bucket=bucket_name)
         except Exception:
-            self.app.log.error(self.app.utilities.get_typed_exception())
+            self.app.log.debug(self.app.utilities.get_typed_exception())
 
         return versioning
 
@@ -58,3 +58,15 @@ class GdsS3Client(GdsAwsClient):
             self.app.log.error(self.app.utilities.get_typed_exception())
 
         return encryption
+
+    def get_bucket_acl(self, session, bucket_name):
+
+        s3 = self.get_boto3_session_client("s3", session)
+        acl = None
+        try:
+            self.app.log.debug(f"Getting ACL for {bucket_name}")
+            acl = s3.get_bucket_acl(Bucket=bucket_name)
+        except Exception:
+            self.app.log.error(self.app.utilities.get_typed_exception())
+
+        return acl

--- a/chalice/chalicelib/aws/gds_support_client.py
+++ b/chalice/chalicelib/aws/gds_support_client.py
@@ -1,6 +1,7 @@
 # GdsSupportClient
 # extends GdsAwsClient
 # implements aws support endpoint queries for Trusted Advisor data
+import time
 from chalicelib.aws.gds_aws_client import GdsAwsClient
 
 
@@ -34,3 +35,38 @@ class GdsSupportClient(GdsAwsClient):
 
         result = response["result"]
         return result
+
+    def refresh_trusted_advisor_check(self, session, **kwargs):
+
+        support = self.get_boto3_session_client("support", session, "us-east-1")
+        response = support.refresh_trusted_advisor_check(**kwargs)
+
+        result = response["status"]
+        return result
+
+    def refresh_check_with_wait(self, session, check_id):
+        updated = False
+        try:
+            update_status = "none"
+
+            retries = 3
+            attempt = 0
+            wait_secs = 0
+            # call update status a maximum of [retries] times
+            while (update_status != "success") and (attempt <= retries):
+                time.sleep(wait_secs)
+
+                response = self.refresh_trusted_advisor_check(
+                    session, checkId=check_id
+                )
+                update_status = response["status"]
+                wait_secs = float(response["millisUntilNextRefreshable"]) / float(1000)
+                attempt += 1
+            updated = update_status == "success"
+
+            if not updated:
+                raise Exception("Not updated")
+        except Exception:
+            self.app.log.debug(f"Check {check_id} could not be refreshed")
+
+        return updated

--- a/chalice/chalicelib/criteria/aws_support_s3_bucket_permissions.py
+++ b/chalice/chalicelib/criteria/aws_support_s3_bucket_permissions.py
@@ -60,8 +60,7 @@ class S3BucketReadAll(S3BucketPermissions):
             "that they are closed to everyone outside of GDS."
         )
         self.how_do_i_fix_it = (
-            "Review the permissions on the listed buckets, and change them to make sure "
-            "that they are no longer open."
+            "Change the bucket permissions ACL Everyone options to remove list permissions."
         )
         super(S3BucketReadAll, self).__init__(app)
 
@@ -103,13 +102,17 @@ class S3BucketOpenAccess(S3BucketPermissions):
             "Therefore it’s vital to secure all S3 buckets by making sure "
             "that they are closed to everyone outside of GDS."
         )
-        self.how_do_i_fix_it = "Review the permissions on the listed buckets, and change them to make sure that they are no longer open."
+        self.how_do_i_fix_it = (
+            "Change the bucket permissions ACL Everyone options to remove the <strong>List objects</strong> permission."
+        )
         super(S3BucketOpenAccess, self).__init__(app)
 
     def evaluate(self, event, item, whitelist=[]):
         compliance_type = "NON_COMPLIANT"
         if item["metadata"][6] == "Yes":
-            self.annotation = "Change the Public Access - Everyone settings on the bucket Permissions ACL"
+            self.annotation = (
+                "The bucket ACL Everyone <strong>List objects</strong> permission is enabled."
+            )
         else:
             compliance_type = "COMPLIANT"
         return self.build_evaluation(
@@ -142,15 +145,16 @@ class S3BucketWriteAll(S3BucketPermissions):
             "Therefore it’s vital to secure all S3 buckets by making sure "
             "that they are closed to everyone outside of GDS."
         )
-        self.how_do_i_fix_it = "Change the Public Access - Everyone settings on the bucket Permissions ACL"
+        self.how_do_i_fix_it = (
+            "Change the bucket permissions ACL Everyone options to remove the <strong>Write objects</strong> permission."
+        )
         super(S3BucketWriteAll, self).__init__(app)
 
     def evaluate(self, event, item, whitelist=[]):
         compliance_type = "NON_COMPLIANT"
         if item["metadata"][4] == "Yes":
             self.annotation = (
-                f'Bucket "{item["metadata"][2]}" in region "{item["metadata"][0]}" policy allows "everyone" '
-                f'or "any authenticated AWS user" to update/delete its contents.'
+                "The bucket ACL Everyone <strong>Write objects</strong> permission is enabled."
             )
         else:
             compliance_type = "COMPLIANT"


### PR DESCRIPTION
I've made a few changes here: 
1. The trusted advisor check get_data method now does a looped retry to refresh the check status to ensure we have current data. I've added a max retry count so it doesn't keep refreshing forever. It's also has a non-actioned except because some TA checks raise a "not refreshable" exception.
2. Add a get_resource_data method to the TA checks to get the raw data associated with the failing resources - This is overridden per check so it doesn't fail if not implemented in a given check.
3. Change the annotation and how_do_i_fix_it entries for the 2 checks mentioned.  