### PR TITLE
CSW-78 - Switch unit test classes to declare app as an instance of the

### DIFF
--- a/chalice/chalicelib/criteria/aws_ec2_security_group_ingress_ssh.py
+++ b/chalice/chalicelib/criteria/aws_ec2_security_group_ingress_ssh.py
@@ -98,6 +98,7 @@ class AwsEc2SecurityGroupIngressSsh(CriteriaDefault):
         Wrapper method: In chalice mode the allow list exceptions are stored in the database
         In CLI mode they are stored in a local JSON file
         """
+        valid_ranges = self.valid_ranges
         if self.app.mode == 'chalice' and self.account_subscription_id is not None:
             valid_ranges = self.get_chalice_valid_ranges()
         elif self.app.mode == 'cli':

--- a/chalice/tests/chalicelib/aws/test_client_default.py
+++ b/chalice/tests/chalicelib/aws/test_client_default.py
@@ -1,5 +1,4 @@
 import unittest
-#from chalice import Chalice
 from app import CloudSecurityWatch
 
 

--- a/chalice/tests/chalicelib/aws/test_client_default.py
+++ b/chalice/tests/chalicelib/aws/test_client_default.py
@@ -1,5 +1,6 @@
 import unittest
-from chalice import Chalice
+#from chalice import Chalice
+from app import CloudSecurityWatch
 
 
 class TestClientDefault(unittest.TestCase):
@@ -12,7 +13,7 @@ class TestClientDefault(unittest.TestCase):
         """
         initialise the the Chalice app objects once to reuse it in every test
         """
-        cls.app = Chalice("test_app")
+        cls.app = CloudSecurityWatch("test_app")
 
 
 if __name__ == "__main__":

--- a/chalice/tests/chalicelib/criteria/test_criteria_default.py
+++ b/chalice/tests/chalicelib/criteria/test_criteria_default.py
@@ -7,7 +7,6 @@ import importlib
 import unittest
 import os
 
-#from chalice import Chalice
 from app import CloudSecurityWatch
 from tests.chalicelib.criteria.test_data import EMPTY_SUMMARY, SESSION
 from chalicelib.criteria.criteria_default import CriteriaDefault

--- a/chalice/tests/chalicelib/criteria/test_criteria_default.py
+++ b/chalice/tests/chalicelib/criteria/test_criteria_default.py
@@ -7,7 +7,8 @@ import importlib
 import unittest
 import os
 
-from chalice import Chalice
+#from chalice import Chalice
+from app import CloudSecurityWatch
 from tests.chalicelib.criteria.test_data import EMPTY_SUMMARY, SESSION
 from chalicelib.criteria.criteria_default import CriteriaDefault
 
@@ -39,7 +40,7 @@ class TestCriteriaDefault(TestCaseWithAttrAssert):
         """
         initialise the the Chalice app objects once to reuse it in every test
         """
-        cls.app = Chalice("test_app")
+        cls.app = CloudSecurityWatch("test_app")
 
     def setUp(self):
         """
@@ -88,7 +89,7 @@ class TestCriteriaDefault(TestCaseWithAttrAssert):
             self.assertIsNone(self.criteria_default.how_do_i_fix_it)
         # vars initialized algorithmically at object instantiation
         with self.subTest():
-            self.assertIsInstance(self.criteria_default.app, Chalice)
+            self.assertIsInstance(self.criteria_default.app, CloudSecurityWatch)
         with self.subTest():
             self.assertIsInstance(self.criteria_default.client, gds_aws_client_class)
 
@@ -240,7 +241,7 @@ class CriteriaSubclassTestCaseMixin(object):
         """
         initialise the the Chalice app objects once to reuse it in every test.
         """
-        cls.app = Chalice("test_app")
+        cls.app = CloudSecurityWatch("test_app")
         cls.test_data = None  # you must load the appropriate test data
 
     def test_init_state(self):

--- a/chalice/tests/chalicelib/test_auth.py
+++ b/chalice/tests/chalicelib/test_auth.py
@@ -4,7 +4,6 @@ import datetime
 import random
 import string
 
-#from chalice import Chalice
 from app import CloudSecurityWatch
 from chalicelib.auth import AuthHandler
 import google_auth_oauthlib.flow

--- a/chalice/tests/chalicelib/test_auth.py
+++ b/chalice/tests/chalicelib/test_auth.py
@@ -4,7 +4,8 @@ import datetime
 import random
 import string
 
-from chalice import Chalice
+#from chalice import Chalice
+from app import CloudSecurityWatch
 from chalicelib.auth import AuthHandler
 import google_auth_oauthlib.flow
 
@@ -23,7 +24,7 @@ class TestAuthHandler(unittest.TestCase):
         """
         """
 
-        self.app = Chalice("test")
+        self.app = CloudSecurityWatch("test")
         self.auth = AuthHandler(self.app)
         self.setUpAuthParameters()
         self.default_login_data = {"authenticated": False, "is_registered": False}

--- a/chalice/tests/chalicelib/test_template_handler.py
+++ b/chalice/tests/chalicelib/test_template_handler.py
@@ -2,7 +2,8 @@ import unittest
 import datetime
 from jinja2 import Environment, Template
 
-from chalice import Chalice
+#from chalice import Chalice
+from app import CloudSecurityWatch
 from chalicelib.auth import AuthHandler
 from chalicelib.template_handler import TemplateHandler
 
@@ -20,7 +21,7 @@ class TestTemplateHandler(unittest.TestCase):
     def setUp(self):
         """
         """
-        self.app = Chalice("test")
+        self.app = CloudSecurityWatch("test")
         self.app.auth = AuthHandler(self.app)
         self.templates = TemplateHandler(self.app)
 

--- a/chalice/tests/chalicelib/test_template_handler.py
+++ b/chalice/tests/chalicelib/test_template_handler.py
@@ -2,7 +2,6 @@ import unittest
 import datetime
 from jinja2 import Environment, Template
 
-#from chalice import Chalice
 from app import CloudSecurityWatch
 from chalicelib.auth import AuthHandler
 from chalicelib.template_handler import TemplateHandler


### PR DESCRIPTION
CloudSecurityWatch sub class rather than native Chalice.

+ declare a default return list for valid ranges for unittest mode