### PR TITLE
Add a boolean field to `account_subscription`

### DIFF
--- a/build/sql/definition/00999.sql
+++ b/build/sql/definition/00999.sql
@@ -1,0 +1,6 @@
+-- Add a boolean to the account_subscriptions table to indicate those accounts
+-- which belong to our organisation and use in coverage reporting.
+-- From: https://trello.com/c/J1Y7YFhy/180-csw-add-a-boolean-to-the-accountsubscriptions-table-to-label-those-accounts-currently-members-of-the-organisation
+
+ALTER TABLE public.account_subscription
+ADD COLUMN in_organisation BOOLEAN DEFAULT FALSE;

--- a/chalice/chalicelib/models.py
+++ b/chalice/chalicelib/models.py
@@ -770,6 +770,7 @@ class AccountSubscription(database_handle.BaseModel):
     active = peewee.BooleanField()
     auditable = peewee.BooleanField()
     suspended = peewee.BooleanField()
+    in_organisation = peewee.BooleanField()
 
     class Meta:
         table_name = "account_subscription"


### PR DESCRIPTION
From the ticket on Trello (https://trello.com/c/J1Y7YFhy/180-csw-add-a-boolean-to-the-accountsubscriptions-table-to-label-those-accounts-currently-members-of-the-organisation)

>Add a boolean to the account_subscriptions table to indicate those accounts which belong to our organisation and use in coverage reporting.

